### PR TITLE
feat: add --model flag and CODEX_REVIEW_MODEL env var support

### DIFF
--- a/plugins/codex-review-core/bin/codex-review.mjs
+++ b/plugins/codex-review-core/bin/codex-review.mjs
@@ -4,8 +4,8 @@
  * codex-review — Codex App Server wrapper for stateful review loops
  *
  * Commands:
- *   start      <prompt-file> <output-file> --session <SID> --review-dir <DIR>
- *   follow-up  <prompt-file> <output-file> --session <SID> --review-dir <DIR>
+ *   start      <prompt-file> <output-file> --session <SID> --review-dir <DIR> [--model <MODEL>]
+ *   follow-up  <prompt-file> <output-file> --session <SID> --review-dir <DIR> [--model <MODEL>]
  *   close      --session <SID> --review-dir <DIR>
  *
  * Exit codes:
@@ -29,7 +29,7 @@ import { resolve } from "node:path";
 
 const TURN_TIMEOUT_MS = 300_000; // 5 minutes
 const INIT_TIMEOUT_MS = 30_000; // 30 seconds
-const MODEL = "gpt-5.3-codex";
+const MODEL = "gpt-5.4";
 
 // ---------------------------------------------------------------------------
 // AppServerClient
@@ -334,7 +334,7 @@ function deleteState(reviewDir, sessionId) {
 // CLI Command Handlers
 // ---------------------------------------------------------------------------
 
-async function cmdStart(promptFile, outputFile, sessionId, reviewDir) {
+async function cmdStart(promptFile, outputFile, sessionId, reviewDir, model) {
   const promptText = readFileSync(promptFile, "utf8");
   const client = new AppServerClient();
 
@@ -344,25 +344,25 @@ async function cmdStart(promptFile, outputFile, sessionId, reviewDir) {
     const account = await client.checkAuth();
     log(`Auth: ${account.type} / ${account.planType} / ${account.email}`);
 
-    const threadResult = await client.startThread({ model: MODEL });
+    const threadResult = await client.startThread({ model });
     const threadId = threadResult.thread.id;
-    log(`Thread created: ${threadId}`);
+    log(`Thread created: ${threadId} (model: ${model})`);
 
     // Save state immediately (before turn, in case of rate limit)
     saveState(reviewDir, sessionId, {
       threadId,
-      model: MODEL,
+      model,
       createdAt: new Date().toISOString(),
       turnCount: 0,
     });
 
-    const turnResult = await client.startTurn(threadId, promptText);
+    const turnResult = await client.startTurn(threadId, promptText, { model });
     log(`Turn completed: ${turnResult.status} (${turnResult.text.length} chars)`);
 
     // Update state with turn count
     saveState(reviewDir, sessionId, {
       threadId,
-      model: MODEL,
+      model,
       createdAt: new Date().toISOString(),
       turnCount: 1,
     });
@@ -375,7 +375,7 @@ async function cmdStart(promptFile, outputFile, sessionId, reviewDir) {
   }
 }
 
-async function cmdFollowUp(promptFile, outputFile, sessionId, reviewDir) {
+async function cmdFollowUp(promptFile, outputFile, sessionId, reviewDir, model) {
   const state = loadState(reviewDir, sessionId);
   if (!state || !state.threadId) {
     throw new CodexError(4, `No active session found for ${sessionId}. Run 'start' first.`);
@@ -384,15 +384,18 @@ async function cmdFollowUp(promptFile, outputFile, sessionId, reviewDir) {
   const promptText = readFileSync(promptFile, "utf8");
   const client = new AppServerClient();
 
+  // Use model from state (recorded at start) unless overridden by caller
+  const effectiveModel = model !== MODEL ? model : (state.model || model);
+
   try {
     await client.spawn();
     await client.initialize();
     await client.checkAuth();
 
     await client.resumeThread(state.threadId);
-    log(`Thread resumed: ${state.threadId}`);
+    log(`Thread resumed: ${state.threadId} (model: ${effectiveModel})`);
 
-    const turnResult = await client.startTurn(state.threadId, promptText);
+    const turnResult = await client.startTurn(state.threadId, promptText, { model: effectiveModel });
     log(`Turn completed: ${turnResult.status} (${turnResult.text.length} chars)`);
 
     // Update state
@@ -422,9 +425,12 @@ function log(msg) {
 
 function printHelp() {
   console.log(`Usage:
-  codex-review start      <prompt-file> <output-file> --session <SID> --review-dir <DIR>
-  codex-review follow-up  <prompt-file> <output-file> --session <SID> --review-dir <DIR>
+  codex-review start      <prompt-file> <output-file> --session <SID> --review-dir <DIR> [--model <MODEL>]
+  codex-review follow-up  <prompt-file> <output-file> --session <SID> --review-dir <DIR> [--model <MODEL>]
   codex-review close      --session <SID> --review-dir <DIR>
+
+Options:
+  --model <MODEL>   Model to use (default: gpt-5.4, env: CODEX_REVIEW_MODEL)
 
 Exit codes:
   0 = success
@@ -447,6 +453,7 @@ function parseArgs(argv) {
 
   let sessionId = null;
   let reviewDir = null;
+  let model = null;
   const positional = [];
 
   for (let i = 1; i < args.length; i++) {
@@ -454,6 +461,8 @@ function parseArgs(argv) {
       sessionId = args[++i];
     } else if (args[i] === "--review-dir" && args[i + 1]) {
       reviewDir = args[++i];
+    } else if (args[i] === "--model" && args[i + 1]) {
+      model = args[++i];
     } else if (!args[i].startsWith("--")) {
       positional.push(args[i]);
     }
@@ -468,7 +477,10 @@ function parseArgs(argv) {
     process.exit(6);
   }
 
-  return { command, positional, sessionId, reviewDir: resolve(reviewDir) };
+  // Priority: CLI arg > env var > default constant
+  const resolvedModel = model || process.env.CODEX_REVIEW_MODEL || MODEL;
+
+  return { command, positional, sessionId, reviewDir: resolve(reviewDir), model: resolvedModel };
 }
 
 // ---------------------------------------------------------------------------
@@ -476,7 +488,7 @@ function parseArgs(argv) {
 // ---------------------------------------------------------------------------
 
 async function main() {
-  const { command, positional, sessionId, reviewDir } = parseArgs(process.argv);
+  const { command, positional, sessionId, reviewDir, model } = parseArgs(process.argv);
 
   try {
     switch (command) {
@@ -485,7 +497,7 @@ async function main() {
           console.error("Error: start requires <prompt-file> <output-file>");
           process.exit(6);
         }
-        await cmdStart(positional[0], positional[1], sessionId, reviewDir);
+        await cmdStart(positional[0], positional[1], sessionId, reviewDir, model);
         break;
       }
       case "follow-up": {
@@ -493,7 +505,7 @@ async function main() {
           console.error("Error: follow-up requires <prompt-file> <output-file>");
           process.exit(6);
         }
-        await cmdFollowUp(positional[0], positional[1], sessionId, reviewDir);
+        await cmdFollowUp(positional[0], positional[1], sessionId, reviewDir, model);
         break;
       }
       case "close": {

--- a/plugins/codex-review-core/bin/codex-review.mjs
+++ b/plugins/codex-review-core/bin/codex-review.mjs
@@ -375,7 +375,7 @@ async function cmdStart(promptFile, outputFile, sessionId, reviewDir, model) {
   }
 }
 
-async function cmdFollowUp(promptFile, outputFile, sessionId, reviewDir, model) {
+async function cmdFollowUp(promptFile, outputFile, sessionId, reviewDir, model, modelExplicit) {
   const state = loadState(reviewDir, sessionId);
   if (!state || !state.threadId) {
     throw new CodexError(4, `No active session found for ${sessionId}. Run 'start' first.`);
@@ -384,8 +384,8 @@ async function cmdFollowUp(promptFile, outputFile, sessionId, reviewDir, model) 
   const promptText = readFileSync(promptFile, "utf8");
   const client = new AppServerClient();
 
-  // Use model from state (recorded at start) unless overridden by caller
-  const effectiveModel = model !== MODEL ? model : (state.model || model);
+  // Use model from state (recorded at start) unless explicitly overridden by --model flag
+  const effectiveModel = modelExplicit ? model : (state.model || MODEL);
 
   try {
     await client.spawn();
@@ -480,7 +480,7 @@ function parseArgs(argv) {
   // Priority: CLI arg > env var > default constant
   const resolvedModel = model || process.env.CODEX_REVIEW_MODEL || MODEL;
 
-  return { command, positional, sessionId, reviewDir: resolve(reviewDir), model: resolvedModel };
+  return { command, positional, sessionId, reviewDir: resolve(reviewDir), model: resolvedModel, modelExplicit: model !== null };
 }
 
 // ---------------------------------------------------------------------------
@@ -488,7 +488,7 @@ function parseArgs(argv) {
 // ---------------------------------------------------------------------------
 
 async function main() {
-  const { command, positional, sessionId, reviewDir, model } = parseArgs(process.argv);
+  const { command, positional, sessionId, reviewDir, model, modelExplicit } = parseArgs(process.argv);
 
   try {
     switch (command) {
@@ -505,7 +505,7 @@ async function main() {
           console.error("Error: follow-up requires <prompt-file> <output-file>");
           process.exit(6);
         }
-        await cmdFollowUp(positional[0], positional[1], sessionId, reviewDir, model);
+        await cmdFollowUp(positional[0], positional[1], sessionId, reviewDir, model, modelExplicit);
         break;
       }
       case "close": {

--- a/plugins/codex-review-rules/rules/review-protocol.md
+++ b/plugins/codex-review-rules/rules/review-protocol.md
@@ -17,6 +17,7 @@
 | Thread 모델 | Stateful — Thread 내에서 follow-up Turn으로 반복 리뷰 가능 |
 | 인증 | ChatGPT 관리형 OAuth (`codex login`으로 사전 인증 필요) |
 | Fallback | 없음 — 실패 시 즉시 PASS |
+| 모델 오버라이드 | `--model <MODEL>` CLI 플래그 또는 `CODEX_REVIEW_MODEL` 환경변수 (기본값: `gpt-5.4`) |
 
 > **App Server 사용 이유**:
 > - Thread 영속성으로 follow-up 시 diff만 전송 → 토큰 ~52% 절감


### PR DESCRIPTION
## Summary

- `--model <MODEL>` CLI 플래그 추가 — 실행 시점에 리뷰 모델 오버라이드 가능
- `CODEX_REVIEW_MODEL` 환경변수 지원
- 기본 모델을 `gpt-5.3-codex` → `gpt-5.4`로 변경

**우선순위**: `--model` > `CODEX_REVIEW_MODEL` > 기본값 (`gpt-5.4`)

## Changes

### `codex-review-core/bin/codex-review.mjs`

- `parseArgs()`: `--model` 파싱 + env var fallback → `resolvedModel` 반환
- `cmdStart()`: `model` 파라미터 수신, `thread/start` · `turn/start` · `saveState` 에 전달
- `cmdFollowUp()`: `effectiveModel` 로직 — 명시적 `--model` 없으면 `state.model` 재사용 (Thread 내 모델 일관성 유지)
- `printHelp()`: `--model` 옵션 및 `CODEX_REVIEW_MODEL` env var 문서화

### `codex-review-rules/rules/review-protocol.md`

- 호출 방식 테이블에 "모델 오버라이드" 행 추가

## Test plan

- [ ] `codex-review --help` 출력에 `--model` 옵션 확인
- [ ] `--model gpt-5.4 start ...` 로 모델 오버라이드 동작 확인
- [ ] `CODEX_REVIEW_MODEL=gpt-5.4 codex-review start ...` 환경변수 fallback 확인
- [ ] `follow-up` 시 `--model` 미지정이면 `state.model` 재사용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)