### PR TITLE
feat: adopt codex-cc features — broker, schema, lifecycle, scope, stop-gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "sanghyun-io's Claude Code plugins",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "plugins": [
     {
       "name": "codex-review-core",
       "source": "./plugins/codex-review-core",
       "description": "Codex App Server wrapper for Claude Code — installs the codex-review CLI binary",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": { "name": "sanghyun-io" },
       "homepage": "https://github.com/sanghyun-io/codex-app-server-plugin",
       "license": "MIT",
@@ -23,7 +23,7 @@
       "name": "codex-review-rules",
       "source": "./plugins/codex-review-rules",
       "description": "Optional rules for Codex-powered plan validation and code review workflows (requires codex-review-core)",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": { "name": "sanghyun-io" },
       "homepage": "https://github.com/sanghyun-io/codex-app-server-plugin",
       "license": "MIT",

--- a/plugins/codex-review-core/.claude-plugin/plugin.json
+++ b/plugins/codex-review-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-review-core",
   "description": "Codex App Server wrapper for Claude Code — installs the codex-review CLI binary",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "sanghyun-io",
     "email": "ppkimsanh@gmail.com"

--- a/plugins/codex-review-core/bin/broker.mjs
+++ b/plugins/codex-review-core/bin/broker.mjs
@@ -1,0 +1,400 @@
+#!/usr/bin/env node
+
+/**
+ * Codex App Server Broker — Persistent IPC serializer
+ *
+ * Holds a single codex app-server subprocess and serializes concurrent
+ * access from multiple workers via a TCP server on localhost.
+ *
+ * Benefits:
+ *   - Eliminates per-turn app-server spawn overhead (~2-3s saved per call)
+ *   - Auth check happens once, reused across all workers
+ *   - Thread management is cleaner (single persistent connection)
+ *
+ * Protocol (line-delimited JSON over TCP):
+ *   Client → Broker:
+ *     { "action": "request", "method": "...", "params": {...}, "id": N, "timeout": MS }
+ *     { "action": "notify",  "method": "...", "params": {...} }
+ *     { "action": "subscribe", "methods": ["item/agentMessage/delta", "turn/completed"] }
+ *     { "action": "unsubscribe" }
+ *     { "action": "ping" }
+ *
+ *   Broker → Client:
+ *     { "type": "response", "id": N, "result": {...} }
+ *     { "type": "response", "id": N, "error": {...} }
+ *     { "type": "notification", "method": "...", "params": {...} }
+ *     { "type": "pong" }
+ *     { "type": "error", "message": "..." }
+ *
+ * Lifecycle:
+ *   - Starts on first worker connection (via ensureBroker() in codex-review.mjs)
+ *   - Auto-shuts down after IDLE_TIMEOUT_MS of no active connections
+ *   - Killed by SessionEnd hook (session-lifecycle.mjs)
+ *
+ * Port file: ~/.claude/tmp/broker.port
+ *   { "port": N, "pid": N, "startedAt": "ISO", "serverInfo": {...} }
+ */
+
+import { createServer } from "node:net";
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import {
+  writeFileSync, unlinkSync, existsSync, mkdirSync,
+} from "node:fs";
+import { resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const HOME = process.env.HOME || process.env.USERPROFILE || "";
+const TMP_DIR = resolve(HOME, ".claude", "tmp");
+const PORT_FILE = resolve(TMP_DIR, "broker.port");
+const IDLE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const INIT_TIMEOUT_MS = 30_000;          // 30s for codex init
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+
+function log(msg) {
+  process.stderr.write(`[broker] ${msg}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// AppServerConnection — wraps the codex app-server subprocess
+// ---------------------------------------------------------------------------
+
+class AppServerConnection {
+  constructor() {
+    this.proc = null;
+    this.rl = null;
+    this.msgId = 0;
+    this.pendingRequests = new Map();
+    this.subscribers = new Set(); // Set of {socket, methods}
+    this.initialized = false;
+    this.serverInfo = null;
+    this.account = null;
+  }
+
+  nextId() { return ++this.msgId; }
+
+  async start() {
+    return new Promise((resolveP, rejectP) => {
+      const customBin = process.env.CODEX_BINARY;
+      if (customBin) {
+        this.proc = spawn(process.execPath, [customBin], {
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      } else {
+        const isWin = process.platform === "win32";
+        this.proc = isWin
+          ? spawn("cmd", ["/c", "codex", "app-server"], {
+              stdio: ["pipe", "pipe", "pipe"],
+            })
+          : spawn("codex", ["app-server"], {
+              stdio: ["pipe", "pipe", "pipe"],
+            });
+      }
+
+      this.proc.on("error", (err) => {
+        if (err.code === "ENOENT") {
+          rejectP(new Error("codex binary not found"));
+        } else {
+          rejectP(new Error(`Process spawn error: ${err.message}`));
+        }
+      });
+
+      this.proc.on("exit", (code) => {
+        log(`App server exited with code ${code}`);
+        this.proc = null;
+      });
+
+      this.rl = createInterface({ input: this.proc.stdout });
+      this.rl.on("line", (line) => {
+        let msg;
+        try { msg = JSON.parse(line); } catch { return; }
+        this._handleMessage(msg);
+      });
+
+      setTimeout(() => resolveP(), 200);
+    });
+  }
+
+  _handleMessage(msg) {
+    // Response to a pending request
+    if (msg.id != null && this.pendingRequests.has(msg.id)) {
+      const { resolve: res, reject: rej, clientId } = this.pendingRequests.get(msg.id);
+      this.pendingRequests.delete(msg.id);
+      msg.error ? rej(msg.error) : res(msg.result);
+      return;
+    }
+
+    // Notification from app-server → forward to subscribers
+    if (msg.method) {
+      for (const sub of this.subscribers) {
+        if (sub.methods.includes("*") || sub.methods.includes(msg.method)) {
+          try {
+            sub.socket.write(JSON.stringify({
+              type: "notification",
+              method: msg.method,
+              params: msg.params,
+            }) + "\n");
+          } catch { /* client disconnected */ }
+        }
+      }
+    }
+  }
+
+  send(msg) {
+    if (!this.proc?.stdin?.writable) {
+      throw new Error("App server not running");
+    }
+    this.proc.stdin.write(JSON.stringify(msg) + "\n");
+  }
+
+  request(method, params, timeoutMs = INIT_TIMEOUT_MS) {
+    return new Promise((resolveP, rejectP) => {
+      const id = this.nextId();
+      const timer = setTimeout(() => {
+        this.pendingRequests.delete(id);
+        rejectP(new Error(`Request ${method} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      this.pendingRequests.set(id, {
+        resolve: (result) => { clearTimeout(timer); resolveP(result); },
+        reject: (error) => { clearTimeout(timer); rejectP(error); },
+      });
+
+      this.send({ method, id, params: params || {} });
+    });
+  }
+
+  notify(method, params) {
+    this.send({ method, params: params || {} });
+  }
+
+  async initialize() {
+    const result = await this.request("initialize", {
+      clientInfo: { name: "codex_review_broker", title: "Codex Review Broker", version: "2.0.0" },
+    });
+    this.notify("initialized");
+    this.serverInfo = result?.serverInfo || {};
+    this.initialized = true;
+    return result;
+  }
+
+  async checkAuth() {
+    const result = await this.request("account/read", { refreshToken: false });
+    const account = result?.account;
+    if (!account || (!account.email && !account.type)) {
+      throw new Error("Not authenticated. Run 'codex login' first.");
+    }
+    this.account = account;
+    return account;
+  }
+
+  addSubscriber(socket, methods) {
+    const sub = { socket, methods };
+    this.subscribers.add(sub);
+    return sub;
+  }
+
+  removeSubscriber(sub) {
+    this.subscribers.delete(sub);
+  }
+
+  close() {
+    this.pendingRequests.clear();
+    this.subscribers.clear();
+    if (this.rl) { this.rl.close(); this.rl = null; }
+    if (this.proc) {
+      try { this.proc.kill(); } catch { /* ignore */ }
+      this.proc = null;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// BrokerServer
+// ---------------------------------------------------------------------------
+
+class BrokerServer {
+  constructor() {
+    this.appServer = new AppServerConnection();
+    this.server = null;
+    this.clients = new Set();
+    this.idleTimer = null;
+  }
+
+  async start() {
+    // Ensure tmp dir exists
+    if (!existsSync(TMP_DIR)) {
+      mkdirSync(TMP_DIR, { recursive: true });
+    }
+
+    // Start codex app-server
+    log("Starting codex app-server...");
+    await this.appServer.start();
+    const initResult = await this.appServer.initialize();
+    log(`App server initialized: ${JSON.stringify(initResult?.serverInfo || {})}`);
+
+    const account = await this.appServer.checkAuth();
+    log(`Authenticated: ${account.type} / ${account.email}`);
+
+    // Start TCP server
+    return new Promise((resolveP) => {
+      this.server = createServer((socket) => this._onConnection(socket));
+      this.server.listen(0, "127.0.0.1", () => {
+        const port = this.server.address().port;
+        log(`Broker listening on 127.0.0.1:${port}`);
+
+        // Write port file
+        const portData = {
+          port,
+          pid: process.pid,
+          startedAt: new Date().toISOString(),
+          serverInfo: this.appServer.serverInfo,
+          account: { email: account.email, type: account.type },
+        };
+        writeFileSync(PORT_FILE, JSON.stringify(portData, null, 2), "utf8");
+
+        this._resetIdleTimer();
+        resolveP(port);
+      });
+    });
+  }
+
+  _onConnection(socket) {
+    this.clients.add(socket);
+    this._resetIdleTimer();
+    log(`Client connected (${this.clients.size} active)`);
+
+    let subscription = null;
+
+    const rl = createInterface({ input: socket });
+    rl.on("line", async (line) => {
+      let msg;
+      try { msg = JSON.parse(line); } catch { return; }
+
+      try {
+        switch (msg.action) {
+          case "request": {
+            const timeoutMs = msg.timeout || INIT_TIMEOUT_MS;
+            const result = await this.appServer.request(msg.method, msg.params, timeoutMs);
+            socket.write(JSON.stringify({ type: "response", id: msg.id, result }) + "\n");
+            break;
+          }
+
+          case "notify":
+            this.appServer.notify(msg.method, msg.params);
+            break;
+
+          case "subscribe":
+            if (subscription) {
+              this.appServer.removeSubscriber(subscription);
+            }
+            subscription = this.appServer.addSubscriber(socket, msg.methods || ["*"]);
+            break;
+
+          case "unsubscribe":
+            if (subscription) {
+              this.appServer.removeSubscriber(subscription);
+              subscription = null;
+            }
+            break;
+
+          case "ping":
+            socket.write(JSON.stringify({ type: "pong" }) + "\n");
+            break;
+
+          default:
+            socket.write(JSON.stringify({
+              type: "error",
+              message: `Unknown action: ${msg.action}`,
+            }) + "\n");
+        }
+      } catch (err) {
+        socket.write(JSON.stringify({
+          type: "response",
+          id: msg.id,
+          error: { message: err.message || String(err) },
+        }) + "\n");
+      }
+    });
+
+    socket.on("close", () => {
+      this.clients.delete(socket);
+      if (subscription) {
+        this.appServer.removeSubscriber(subscription);
+      }
+      rl.close();
+      log(`Client disconnected (${this.clients.size} active)`);
+      this._resetIdleTimer();
+    });
+
+    socket.on("error", () => {
+      this.clients.delete(socket);
+      if (subscription) {
+        this.appServer.removeSubscriber(subscription);
+      }
+    });
+  }
+
+  _resetIdleTimer() {
+    if (this.idleTimer) clearTimeout(this.idleTimer);
+    if (this.clients.size === 0) {
+      this.idleTimer = setTimeout(() => {
+        log(`Idle timeout (${IDLE_TIMEOUT_MS / 1000}s) — shutting down`);
+        this.shutdown();
+      }, IDLE_TIMEOUT_MS);
+    }
+  }
+
+  shutdown() {
+    log("Shutting down broker...");
+
+    // Clean up port file
+    try { unlinkSync(PORT_FILE); } catch { /* ignore */ }
+
+    // Close all client connections
+    for (const socket of this.clients) {
+      try { socket.destroy(); } catch { /* ignore */ }
+    }
+    this.clients.clear();
+
+    // Close TCP server
+    if (this.server) {
+      this.server.close();
+      this.server = null;
+    }
+
+    // Close app-server
+    this.appServer.close();
+
+    process.exit(0);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const broker = new BrokerServer();
+
+  // Graceful shutdown signals
+  process.on("SIGTERM", () => broker.shutdown());
+  process.on("SIGINT", () => broker.shutdown());
+
+  try {
+    await broker.start();
+  } catch (err) {
+    log(`Fatal: ${err.message}`);
+    // Clean up port file on failure
+    try { unlinkSync(PORT_FILE); } catch { /* ignore */ }
+    process.exit(1);
+  }
+}
+
+main();

--- a/plugins/codex-review-core/bin/codex-review.mjs
+++ b/plugins/codex-review-core/bin/codex-review.mjs
@@ -27,11 +27,12 @@
  *   8 = turn cancelled
  */
 
-import { spawn } from "node:child_process";
+import { spawn, execSync } from "node:child_process";
 import { createInterface } from "node:readline";
+import { createConnection } from "node:net";
 import {
   readFileSync, writeFileSync, unlinkSync, existsSync,
-  openSync, closeSync, renameSync,
+  openSync, closeSync, renameSync, mkdirSync,
 } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -79,14 +80,22 @@ class AppServerClient {
 
   async spawn() {
     return new Promise((resolveP, rejectP) => {
-      const isWin = process.platform === "win32";
-      this.proc = isWin
-        ? spawn("cmd", ["/c", "codex", "app-server"], {
-            stdio: ["pipe", "pipe", "pipe"],
-          })
-        : spawn("codex", ["app-server"], {
-            stdio: ["pipe", "pipe", "pipe"],
-          });
+      const customBin = process.env.CODEX_BINARY;
+      if (customBin) {
+        // Custom binary (e.g. fake-codex.mjs for testing)
+        this.proc = spawn(process.execPath, [customBin], {
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      } else {
+        const isWin = process.platform === "win32";
+        this.proc = isWin
+          ? spawn("cmd", ["/c", "codex", "app-server"], {
+              stdio: ["pipe", "pipe", "pipe"],
+            })
+          : spawn("codex", ["app-server"], {
+              stdio: ["pipe", "pipe", "pipe"],
+            });
+      }
 
       this.proc.on("error", (err) => {
         if (err.code === "ENOENT") {
@@ -323,6 +332,304 @@ class AppServerClient {
 }
 
 // ---------------------------------------------------------------------------
+// BrokerClient — connects to a running broker instead of spawning app-server
+// ---------------------------------------------------------------------------
+
+const BROKER_HOME = process.env.HOME || process.env.USERPROFILE || "";
+const BROKER_TMP = resolve(BROKER_HOME, ".claude", "tmp");
+const BROKER_PORT_FILE = resolve(BROKER_TMP, "broker.port");
+const BROKER_SCRIPT = resolve(dirname(SELF), "broker.mjs");
+
+class BrokerClient {
+  constructor() {
+    this.socket = null;
+    this.rl = null;
+    this.msgId = 0;
+    this.pendingRequests = new Map();
+    this.notificationHandlers = new Map();
+  }
+
+  nextId() { return ++this.msgId; }
+
+  async connect(port) {
+    return new Promise((resolveP, rejectP) => {
+      this.socket = createConnection({ host: "127.0.0.1", port }, () => {
+        this.rl = createInterface({ input: this.socket });
+        this.rl.on("line", (line) => {
+          let msg;
+          try { msg = JSON.parse(line); } catch { return; }
+          this._handleMessage(msg);
+        });
+        resolveP();
+      });
+      this.socket.on("error", (err) => {
+        rejectP(new Error(`Broker connection failed: ${err.message}`));
+      });
+    });
+  }
+
+  _handleMessage(msg) {
+    if (msg.type === "response" && msg.id != null && this.pendingRequests.has(msg.id)) {
+      const { resolve: res, reject: rej } = this.pendingRequests.get(msg.id);
+      this.pendingRequests.delete(msg.id);
+      msg.error ? rej(msg.error) : res(msg.result);
+      return;
+    }
+    if (msg.type === "notification" && msg.method) {
+      const handler = this.notificationHandlers.get(msg.method);
+      if (handler) handler(msg.params);
+      const wildcard = this.notificationHandlers.get("*");
+      if (wildcard) wildcard(msg.method, msg.params);
+    }
+  }
+
+  send(data) {
+    if (!this.socket?.writable) {
+      throw new CodexError(6, "Broker connection not writable");
+    }
+    this.socket.write(JSON.stringify(data) + "\n");
+  }
+
+  request(method, params, timeoutMs = INIT_TIMEOUT_MS) {
+    return new Promise((resolveP, rejectP) => {
+      const id = this.nextId();
+      const timer = setTimeout(() => {
+        this.pendingRequests.delete(id);
+        rejectP(new CodexError(5, `Broker request ${method} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      this.pendingRequests.set(id, {
+        resolve: (result) => { clearTimeout(timer); resolveP(result); },
+        reject: (error) => { clearTimeout(timer); rejectP(error); },
+      });
+
+      this.send({ action: "request", method, params: params || {}, id, timeout: timeoutMs });
+    });
+  }
+
+  notify(method, params) {
+    this.send({ action: "notify", method, params: params || {} });
+  }
+
+  subscribe(methods = ["*"]) {
+    this.send({ action: "subscribe", methods });
+  }
+
+  onNotification(method, handler) {
+    this.notificationHandlers.set(method, handler);
+  }
+
+  // -- High-level operations (same interface as AppServerClient) --
+
+  async initialize() {
+    // Broker is already initialized — just return cached info
+    return { serverInfo: { name: "broker-proxy" } };
+  }
+
+  async checkAuth() {
+    // Broker already checked auth on startup — ping to verify connection
+    this.send({ action: "ping" });
+    return { email: "broker-cached", type: "broker" };
+  }
+
+  async startThread(opts = {}) {
+    return await this.request("thread/start", {
+      model: opts.model || DEFAULT_MODEL,
+      approvalPolicy: "never",
+      ...opts,
+    });
+  }
+
+  async resumeThread(threadId) {
+    try {
+      return await this.request("thread/resume", { threadId });
+    } catch (err) {
+      if (err.message?.includes("no rollout found")) {
+        throw new CodexError(4, `Thread resume failed: ${err.message}`);
+      }
+      throw new CodexError(4, `Thread resume failed: ${err.message || JSON.stringify(err)}`);
+    }
+  }
+
+  async startTurn(threadId, inputText, opts = {}) {
+    const timeoutMs = opts.timeout ?? DEFAULT_HARD_TIMEOUT_MS;
+    const onDelta = opts.onDelta || (() => {});
+    const cancelSignal = opts.cancelSignal || (() => false);
+
+    // Subscribe to turn notifications
+    this.subscribe(["item/agentMessage/delta", "turn/completed", "error"]);
+
+    return new Promise((resolveP, rejectP) => {
+      let agentText = "";
+      let resolved = false;
+
+      const cleanup = () => {
+        if (hardTimer) clearTimeout(hardTimer);
+        if (cancelChecker) clearInterval(cancelChecker);
+        for (const [, pending] of this.pendingRequests) {
+          pending.resolve(null);
+        }
+        this.pendingRequests.clear();
+      };
+
+      const finish = (result) => {
+        if (resolved) return;
+        resolved = true;
+        cleanup();
+        resolveP(result);
+      };
+
+      const fail = (err) => {
+        if (resolved) return;
+        resolved = true;
+        cleanup();
+        rejectP(err);
+      };
+
+      const hardTimer = timeoutMs > 0
+        ? setTimeout(() => {
+            if (agentText.length > 0) {
+              finish({ text: agentText, status: "timeout_partial" });
+            } else {
+              fail(new CodexError(5, `Turn timed out after ${timeoutMs}ms with no response`));
+            }
+          }, timeoutMs)
+        : null;
+
+      const cancelChecker = setInterval(() => {
+        if (cancelSignal()) {
+          finish({ text: agentText, status: "cancelled" });
+        }
+      }, CANCEL_CHECK_MS);
+
+      this.onNotification("item/agentMessage/delta", (params) => {
+        agentText += params?.delta || "";
+        onDelta(agentText.length);
+      });
+
+      this.onNotification("turn/completed", (params) => {
+        const turn = params?.turn;
+        if (turn?.status === "completed") {
+          finish({ text: agentText, status: "completed" });
+        } else if (turn?.status === "failed") {
+          const error = turn?.error || params?.error;
+          const errMsg = error?.message || "Turn failed";
+          if (error?.codexErrorInfo === "usageLimitExceeded" || errMsg.includes("usage limit")) {
+            fail(new CodexError(3, `Rate limit exceeded: ${errMsg}`));
+          } else {
+            fail(new CodexError(6, `Turn failed: ${errMsg}`));
+          }
+        } else {
+          finish({ text: agentText, status: turn?.status || "unknown" });
+        }
+      });
+
+      this.onNotification("error", (params) => {
+        const error = params?.error;
+        if (error?.codexErrorInfo === "usageLimitExceeded") {
+          fail(new CodexError(3, `Rate limit exceeded: ${error.message}`));
+        }
+      });
+
+      this.request(
+        "turn/start",
+        {
+          threadId,
+          input: [{ type: "text", text: inputText }],
+          model: opts.model || DEFAULT_MODEL,
+          effort: opts.effort || "high",
+        },
+        timeoutMs || DEFAULT_HARD_TIMEOUT_MS
+      ).catch((err) => {
+        fail(err instanceof CodexError ? err : new CodexError(6, `Turn start failed: ${err.message || JSON.stringify(err)}`));
+      });
+    });
+  }
+
+  close() {
+    this.notificationHandlers.clear();
+    this.pendingRequests.clear();
+    if (this.rl) { this.rl.close(); this.rl = null; }
+    if (this.socket) {
+      try { this.socket.destroy(); } catch { /* ignore */ }
+      this.socket = null;
+    }
+  }
+}
+
+/**
+ * Try to connect to an existing broker. If no broker is running, start one
+ * as a detached process and wait for it to become ready.
+ *
+ * Returns a connected BrokerClient, or null if broker is unavailable
+ * (caller should fall back to direct AppServerClient).
+ */
+async function connectOrStartBroker() {
+  // Check for existing broker
+  if (existsSync(BROKER_PORT_FILE)) {
+    const portData = readJson(BROKER_PORT_FILE);
+    if (portData?.port && portData?.pid) {
+      // Verify broker is alive
+      if (isAlive(portData.pid)) {
+        try {
+          const client = new BrokerClient();
+          await client.connect(portData.port);
+          log("Connected to existing broker");
+          return client;
+        } catch {
+          log("Broker port file exists but connection failed, starting new broker");
+        }
+      } else {
+        removeFile(BROKER_PORT_FILE);
+      }
+    }
+  }
+
+  // Start new broker
+  if (!existsSync(BROKER_SCRIPT)) {
+    log("Broker script not found, falling back to direct connection");
+    return null;
+  }
+
+  if (!existsSync(BROKER_TMP)) {
+    mkdirSync(BROKER_TMP, { recursive: true });
+  }
+
+  log("Starting new broker...");
+  const logPath = resolve(BROKER_TMP, "broker.log");
+  const logFd = openSync(logPath, "w");
+
+  const brokerProc = spawn(process.execPath, [BROKER_SCRIPT], {
+    detached: true,
+    stdio: ["ignore", logFd, logFd],
+    env: process.env,
+  });
+  brokerProc.unref();
+  closeSync(logFd);
+
+  // Wait for broker to write port file (up to 15s)
+  for (let i = 0; i < 30; i++) {
+    await sleep(500);
+    if (existsSync(BROKER_PORT_FILE)) {
+      const portData = readJson(BROKER_PORT_FILE);
+      if (portData?.port) {
+        try {
+          const client = new BrokerClient();
+          await client.connect(portData.port);
+          log(`Connected to new broker on port ${portData.port}`);
+          return client;
+        } catch {
+          // Broker not ready yet, keep waiting
+        }
+      }
+    }
+  }
+
+  log("Broker startup timeout, falling back to direct connection");
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // File helpers
 // ---------------------------------------------------------------------------
 
@@ -437,13 +744,23 @@ async function workerMain(parsed) {
 
   progress("initializing");
 
-  const client = new AppServerClient();
+  // Try broker first, fall back to direct AppServerClient
+  // Broker can be disabled via env (useful for testing with fake-codex)
+  const brokerDisabled = !!process.env.CODEX_REVIEW_NO_BROKER;
+  let client = brokerDisabled ? null : await connectOrStartBroker();
+  let usedBroker = !!client;
 
-  try {
+  if (!client) {
+    client = new AppServerClient();
     await client.spawn();
     await client.initialize();
     const account = await client.checkAuth();
-    log(`Auth: ${account.type} / ${account.planType} / ${account.email}`);
+    log(`Auth (direct): ${account.type} / ${account.planType} / ${account.email}`);
+  } else {
+    log("Using broker connection (auth cached)");
+  }
+
+  try {
 
     let threadId;
     let effectiveModel = model;
@@ -784,6 +1101,123 @@ async function cmdClose(parsed) {
 }
 
 // ---------------------------------------------------------------------------
+// CLI Command: scope
+// ---------------------------------------------------------------------------
+
+const SCOPE_THRESHOLDS = {
+  // Files changed thresholds
+  SMALL_FILES: 5,
+  LARGE_FILES: 20,
+  // Total lines changed thresholds
+  SMALL_LINES: 100,
+  LARGE_LINES: 500,
+  // Untracked file size cap (bytes)
+  UNTRACKED_CAP: 24_576,    // 24 KB
+  // Inline diff size cap (chars)
+  DIFF_CAP: 262_144,        // 256 KB
+};
+
+function cmdScope(parsed) {
+  const base = parsed.positional[0] || null; // optional base ref
+
+  let shortstat = "";
+  let filesChanged = 0;
+  let insertions = 0;
+  let deletions = 0;
+  let untrackedCount = 0;
+  let totalLines = 0;
+
+  try {
+    // Determine diff base
+    let diffCmd;
+    if (base) {
+      diffCmd = `git diff --shortstat ${base}...HEAD`;
+    } else {
+      // Try current branch vs default branch
+      let defaultBranch;
+      try {
+        defaultBranch = execSync(
+          "git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'",
+          { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }
+        ).trim();
+      } catch {
+        defaultBranch = "main";
+      }
+
+      // Check for uncommitted changes first
+      const uncommitted = execSync("git diff --shortstat", { encoding: "utf8" }).trim();
+      const staged = execSync("git diff --cached --shortstat", { encoding: "utf8" }).trim();
+
+      if (uncommitted || staged) {
+        // Working tree mode: uncommitted + staged changes
+        diffCmd = "git diff HEAD --shortstat";
+      } else {
+        // Branch mode: current branch vs default
+        diffCmd = `git diff ${defaultBranch}...HEAD --shortstat`;
+      }
+    }
+
+    shortstat = execSync(diffCmd, { encoding: "utf8" }).trim();
+
+    // Parse shortstat: "N files changed, N insertions(+), N deletions(-)"
+    const filesMatch = shortstat.match(/(\d+) files? changed/);
+    const insMatch = shortstat.match(/(\d+) insertions?\(\+\)/);
+    const delMatch = shortstat.match(/(\d+) deletions?\(-\)/);
+
+    filesChanged = filesMatch ? parseInt(filesMatch[1], 10) : 0;
+    insertions = insMatch ? parseInt(insMatch[1], 10) : 0;
+    deletions = delMatch ? parseInt(delMatch[1], 10) : 0;
+    totalLines = insertions + deletions;
+
+    // Count untracked files
+    try {
+      const untracked = execSync("git ls-files --others --exclude-standard", { encoding: "utf8" }).trim();
+      untrackedCount = untracked ? untracked.split("\n").length : 0;
+    } catch { /* ignore */ }
+
+  } catch (err) {
+    // Not in a git repo or git command failed
+    console.log(JSON.stringify({
+      error: `Git command failed: ${err.message}`,
+      recommendation: "foreground",
+    }, null, 2));
+    process.exit(0);
+    return;
+  }
+
+  // Determine recommendation
+  let recommendation;
+  let reason;
+
+  if (totalLines <= SCOPE_THRESHOLDS.SMALL_LINES && filesChanged <= SCOPE_THRESHOLDS.SMALL_FILES) {
+    recommendation = "foreground";
+    reason = `Small change (${filesChanged} files, ${totalLines} lines)`;
+  } else if (totalLines >= SCOPE_THRESHOLDS.LARGE_LINES || filesChanged >= SCOPE_THRESHOLDS.LARGE_FILES) {
+    recommendation = "background";
+    reason = `Large change (${filesChanged} files, ${totalLines} lines) — background recommended for non-blocking execution`;
+  } else {
+    recommendation = "either";
+    reason = `Medium change (${filesChanged} files, ${totalLines} lines) — either mode works`;
+  }
+
+  const result = {
+    files_changed: filesChanged,
+    insertions,
+    deletions,
+    total_lines: totalLines,
+    untracked_files: untrackedCount,
+    recommendation,
+    reason,
+    thresholds: {
+      untracked_cap_bytes: SCOPE_THRESHOLDS.UNTRACKED_CAP,
+      diff_cap_chars: SCOPE_THRESHOLDS.DIFF_CAP,
+    },
+  };
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+// ---------------------------------------------------------------------------
 // CLI parsing
 // ---------------------------------------------------------------------------
 
@@ -796,6 +1230,7 @@ Usage:
   codex-review status     --session <SID> --review-dir <DIR>
   codex-review cancel     --session <SID> --review-dir <DIR>
   codex-review close      --session <SID> --review-dir <DIR>
+  codex-review scope      [<base-ref>]
 
 Options:
   --model <MODEL>       Model to use (default: gpt-5.4, env: CODEX_REVIEW_MODEL)
@@ -857,6 +1292,22 @@ function parseArgs(argv) {
     }
   }
 
+  // scope command doesn't require --session / --review-dir
+  if (command === "scope") {
+    return {
+      command,
+      positional,
+      sessionId: sessionId || "",
+      reviewDir: reviewDir ? resolve(reviewDir) : "",
+      model: model || process.env.CODEX_REVIEW_MODEL || DEFAULT_MODEL,
+      modelExplicit: model !== null,
+      timeout: DEFAULT_HARD_TIMEOUT_MS,
+      nonce,
+      foreground,
+      isWorker,
+    };
+  }
+
   // Validate required args
   if (!sessionId) {
     console.error("Error: --session <SID> is required");
@@ -916,6 +1367,9 @@ async function main() {
         break;
       case "close":
         await cmdClose(parsed);
+        break;
+      case "scope":
+        cmdScope(parsed);
         break;
       default:
         console.error(`Unknown command: ${parsed.command}`);

--- a/plugins/codex-review-core/hooks/hooks.json
+++ b/plugins/codex-review-core/hooks/hooks.json
@@ -6,7 +6,43 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/install.sh",
-            "description": "Install codex-review binary to ~/.claude/bin/"
+            "description": "Install codex-review binary, schemas, and hook scripts to ~/.claude/"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/session-lifecycle.mjs start",
+            "timeout": 5000,
+            "description": "Export session metadata for worker coordination"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/session-lifecycle.mjs end",
+            "timeout": 10000,
+            "description": "Kill running workers, shut down broker, clean up temp files"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/stop-gate.mjs",
+            "timeout": 30000,
+            "description": "Quality gate: check for active reviews and uncommitted changes before stopping"
           }
         ]
       }

--- a/plugins/codex-review-core/schemas/review-output.schema.json
+++ b/plugins/codex-review-core/schemas/review-output.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Codex Review Output",
+  "description": "Structured output schema for plan validation and code review results. Enables machine-readable parsing for automated follow-up actions.",
+  "type": "object",
+  "required": ["verdict", "summary", "findings"],
+  "additionalProperties": false,
+  "properties": {
+    "verdict": {
+      "type": "string",
+      "enum": ["approve", "revise", "reject"],
+      "description": "Overall review verdict"
+    },
+    "summary": {
+      "type": "string",
+      "description": "One-paragraph summary of the review findings"
+    },
+    "findings": {
+      "type": "array",
+      "description": "List of issues found during review",
+      "items": {
+        "type": "object",
+        "required": ["number", "severity", "area", "title", "problem", "recommendation"],
+        "additionalProperties": false,
+        "properties": {
+          "number": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Issue number"
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["high", "medium", "low"],
+            "description": "Issue severity level"
+          },
+          "area": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 4,
+            "description": "Review area: 1=Architecture, 2=Implementation, 3=Testing, 4=Performance"
+          },
+          "title": {
+            "type": "string",
+            "description": "Short issue title"
+          },
+          "file": {
+            "type": "string",
+            "description": "File path with optional line reference (code review only)"
+          },
+          "line_start": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Start line number (code review only)"
+          },
+          "line_end": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "End line number (code review only)"
+          },
+          "problem": {
+            "type": "object",
+            "required": ["what", "why", "impact"],
+            "additionalProperties": false,
+            "properties": {
+              "what": { "type": "string", "description": "What is wrong" },
+              "why": { "type": "string", "description": "Root cause" },
+              "impact": { "type": "string", "description": "Actual harm or risk" }
+            }
+          },
+          "options": {
+            "type": "array",
+            "description": "Recommended actions",
+            "items": {
+              "type": "object",
+              "required": ["label", "description"],
+              "additionalProperties": false,
+              "properties": {
+                "label": { "type": "string", "description": "Option label, e.g. (A)" },
+                "description": { "type": "string" },
+                "effort": { "type": "string" },
+                "risk": { "type": "string" },
+                "impact": { "type": "string" }
+              }
+            }
+          },
+          "recommendation": {
+            "type": "string",
+            "description": "Recommended option with reasoning"
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Confidence score (0-1) for this finding"
+          }
+        }
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "description": "Suggested next steps after review",
+      "items": { "type": "string" }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "model": { "type": "string", "description": "Model used for review" },
+        "round": { "type": "integer", "description": "Review round number" },
+        "review_type": { "type": "string", "enum": ["plan", "code"] },
+        "elapsed_ms": { "type": "integer", "description": "Time taken in milliseconds" },
+        "thread_id": { "type": "string", "description": "Codex thread ID" },
+        "turn_count": { "type": "integer", "description": "Number of turns in thread" }
+      }
+    }
+  }
+}

--- a/plugins/codex-review-core/scripts/install.sh
+++ b/plugins/codex-review-core/scripts/install.sh
@@ -25,6 +25,35 @@ cp "$PLUGIN_ROOT/bin/codex-review.mjs" "$BIN_DIR/"
 chmod +x "$BIN_DIR/codex-review.mjs"
 echo -e "✓ Installed ${GREEN}~/.claude/bin/codex-review.mjs${NC}"
 
+# Install bin/broker.mjs → ~/.claude/bin/
+if [ -f "$PLUGIN_ROOT/bin/broker.mjs" ]; then
+  cp "$PLUGIN_ROOT/bin/broker.mjs" "$BIN_DIR/"
+  chmod +x "$BIN_DIR/broker.mjs"
+  echo -e "✓ Installed ${GREEN}~/.claude/bin/broker.mjs${NC}"
+fi
+
+# Install schemas → ~/.claude/schemas/
+SCHEMA_DIR="$HOME/.claude/schemas"
+mkdir -p "$SCHEMA_DIR"
+if [ -d "$PLUGIN_ROOT/schemas" ]; then
+  for schema_file in "$PLUGIN_ROOT/schemas"/*.json; do
+    if [ -f "$schema_file" ]; then
+      filename=$(basename "$schema_file")
+      cp "$schema_file" "$SCHEMA_DIR/"
+      echo -e "✓ Installed ${GREEN}~/.claude/schemas/${filename}${NC}"
+    fi
+  done
+fi
+
+# Install scripts → ~/.claude/bin/ (lifecycle hooks)
+for script_file in session-lifecycle.mjs stop-gate.mjs; do
+  if [ -f "$PLUGIN_ROOT/scripts/$script_file" ]; then
+    cp "$PLUGIN_ROOT/scripts/$script_file" "$BIN_DIR/"
+    chmod +x "$BIN_DIR/$script_file"
+    echo -e "✓ Installed ${GREEN}~/.claude/bin/${script_file}${NC}"
+  fi
+done
+
 echo ""
 echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${GREEN}✓ Installation complete!${NC}"

--- a/plugins/codex-review-core/scripts/session-lifecycle.mjs
+++ b/plugins/codex-review-core/scripts/session-lifecycle.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+/**
+ * Session Lifecycle Hook — SessionStart / SessionEnd handler
+ *
+ * SessionStart: Exports session metadata to env file for worker coordination.
+ * SessionEnd:   Kills all running workers, shuts down broker, cleans up temp files.
+ *
+ * Invoked by Claude Code hooks system via hooks.json.
+ *
+ * Environment:
+ *   CLAUDE_SESSION_ID   — Current session ID (set by Claude Code)
+ *   CLAUDE_PLUGIN_ROOT  — Plugin root directory
+ *   HOME                — User home directory
+ */
+
+import { existsSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const HOME = process.env.HOME || process.env.USERPROFILE || "";
+const TMP_DIR = resolve(HOME, ".claude", "tmp");
+const SESSION_ID = process.env.CLAUDE_SESSION_ID || "";
+const HOOK_EVENT = process.argv[2] || ""; // "start" or "end"
+
+function log(msg) {
+  process.stderr.write(`[session-lifecycle] ${msg}\n`);
+}
+
+function isAlive(pid) {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+function readJson(path) {
+  if (!existsSync(path)) return null;
+  try { return JSON.parse(readFileSync(path, "utf8")); } catch { return null; }
+}
+
+function removeFile(path) {
+  if (existsSync(path)) { try { unlinkSync(path); } catch { /* ignore */ } }
+}
+
+// ---------------------------------------------------------------------------
+// SessionStart
+// ---------------------------------------------------------------------------
+
+function onSessionStart() {
+  // Write session env file for worker coordination
+  const envPath = resolve(TMP_DIR, `session_${SESSION_ID}.env`);
+  const envContent = [
+    `SESSION_ID=${SESSION_ID}`,
+    `STARTED_AT=${new Date().toISOString()}`,
+    `TMP_DIR=${TMP_DIR}`,
+  ].join("\n");
+
+  try {
+    writeFileSync(envPath, envContent, "utf8");
+    log(`Session started: ${SESSION_ID}`);
+  } catch (err) {
+    log(`Warning: Could not write session env: ${err.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SessionEnd
+// ---------------------------------------------------------------------------
+
+function onSessionEnd() {
+  if (!existsSync(TMP_DIR)) {
+    log("No tmp directory found, nothing to clean up");
+    return;
+  }
+
+  let killedWorkers = 0;
+  let cleanedFiles = 0;
+
+  try {
+    const files = readdirSync(TMP_DIR);
+
+    // 1. Kill all running workers (find PID files)
+    const pidFiles = files.filter(f => f.endsWith("_pid"));
+    for (const pidFile of pidFiles) {
+      const pidPath = resolve(TMP_DIR, pidFile);
+      const pidData = readJson(pidPath);
+      if (!pidData) continue;
+
+      const pid = pidData.pid;
+      if (pid && isAlive(pid)) {
+        try {
+          process.kill(pid, "SIGTERM");
+          killedWorkers++;
+          log(`Killed worker PID ${pid} (${pidFile})`);
+        } catch (err) {
+          log(`Warning: Could not kill PID ${pid}: ${err.message}`);
+        }
+      }
+      removeFile(pidPath);
+    }
+
+    // 2. Kill broker if running
+    const brokerPortFile = resolve(TMP_DIR, "broker.port");
+    const brokerData = readJson(brokerPortFile);
+    if (brokerData?.pid && isAlive(brokerData.pid)) {
+      try {
+        process.kill(brokerData.pid, "SIGTERM");
+        log(`Killed broker PID ${brokerData.pid}`);
+      } catch { /* ignore */ }
+    }
+    removeFile(brokerPortFile);
+
+    // 3. Clean up session files (progress, state, logs, env)
+    const sessionPatterns = ["_progress.json", "_state.json", "_worker.log"];
+    for (const file of files) {
+      if (sessionPatterns.some(p => file.endsWith(p))) {
+        removeFile(resolve(TMP_DIR, file));
+        cleanedFiles++;
+      }
+    }
+
+    // Clean up session env file
+    const envFile = resolve(TMP_DIR, `session_${SESSION_ID}.env`);
+    removeFile(envFile);
+
+    log(`Session ended: killed ${killedWorkers} worker(s), cleaned ${cleanedFiles} file(s)`);
+  } catch (err) {
+    log(`Warning: Cleanup error: ${err.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+if (HOOK_EVENT === "start") {
+  onSessionStart();
+} else if (HOOK_EVENT === "end") {
+  onSessionEnd();
+} else {
+  // Auto-detect from hook type name
+  const hookType = process.env.CLAUDE_HOOK_TYPE || "";
+  if (hookType === "SessionStart" || hookType.toLowerCase().includes("start")) {
+    onSessionStart();
+  } else {
+    onSessionEnd();
+  }
+}

--- a/plugins/codex-review-core/scripts/stop-gate.mjs
+++ b/plugins/codex-review-core/scripts/stop-gate.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+/**
+ * Stop Gate Hook — Quality gate before session termination
+ *
+ * When enabled (stopReviewGate: true in state), this hook runs before
+ * Claude Code stops. It checks for:
+ *   1. Active/incomplete review sessions (workers still running)
+ *   2. Uncommitted changes that haven't been reviewed
+ *
+ * Output:
+ *   First line MUST be "ALLOW: <reason>" or "BLOCK: <reason>"
+ *   - ALLOW: session can terminate normally
+ *   - BLOCK: session termination is blocked (user must address the issue)
+ *
+ * Environment:
+ *   HOME — User home directory
+ *
+ * Configuration:
+ *   State file: ~/.claude/tmp/codex_review_config.json
+ *   { "stopReviewGate": true/false }
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { execSync } from "node:child_process";
+
+const HOME = process.env.HOME || process.env.USERPROFILE || "";
+const TMP_DIR = resolve(HOME, ".claude", "tmp");
+const CONFIG_PATH = resolve(TMP_DIR, "codex_review_config.json");
+
+function log(msg) {
+  process.stderr.write(`[stop-gate] ${msg}\n`);
+}
+
+function readJson(path) {
+  if (!existsSync(path)) return null;
+  try { return JSON.parse(readFileSync(path, "utf8")); } catch { return null; }
+}
+
+function isAlive(pid) {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+function allow(reason) {
+  console.log(`ALLOW: ${reason}`);
+  process.exit(0);
+}
+
+function block(reason) {
+  console.log(`BLOCK: ${reason}`);
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  // Check if gate is enabled
+  const config = readJson(CONFIG_PATH);
+  if (!config?.stopReviewGate) {
+    allow("Stop review gate is disabled");
+    return;
+  }
+
+  // Check 1: Any workers still running?
+  if (existsSync(TMP_DIR)) {
+    try {
+      const files = readdirSync(TMP_DIR);
+      const pidFiles = files.filter(f => f.endsWith("_pid"));
+      const runningWorkers = [];
+
+      for (const pidFile of pidFiles) {
+        const pidPath = resolve(TMP_DIR, pidFile);
+        const pidData = readJson(pidPath);
+        if (pidData?.pid && isAlive(pidData.pid)) {
+          // Check progress to see what session it belongs to
+          const sessionId = pidFile.replace("_pid", "");
+          const progressPath = resolve(TMP_DIR, `${sessionId}_progress.json`);
+          const progress = readJson(progressPath);
+          runningWorkers.push({
+            session: sessionId,
+            pid: pidData.pid,
+            status: progress?.status || "unknown",
+            elapsed: progress?.elapsedMs || 0,
+          });
+        }
+      }
+
+      if (runningWorkers.length > 0) {
+        const summary = runningWorkers
+          .map(w => `${w.session} (PID ${w.pid}, ${w.status}, ${Math.round(w.elapsed / 1000)}s)`)
+          .join("; ");
+        block(`${runningWorkers.length} review worker(s) still running: ${summary}`);
+        return;
+      }
+    } catch (err) {
+      log(`Warning: Could not check workers: ${err.message}`);
+    }
+  }
+
+  // Check 2: Any incomplete review sessions (progress = running/initializing)?
+  if (existsSync(TMP_DIR)) {
+    try {
+      const files = readdirSync(TMP_DIR);
+      const progressFiles = files.filter(f => f.endsWith("_progress.json"));
+      const incomplete = [];
+
+      for (const pFile of progressFiles) {
+        const progress = readJson(resolve(TMP_DIR, pFile));
+        if (progress && ["running", "initializing", "queued"].includes(progress.status)) {
+          incomplete.push(pFile.replace("_progress.json", ""));
+        }
+      }
+
+      if (incomplete.length > 0) {
+        block(`${incomplete.length} review session(s) appear incomplete: ${incomplete.join(", ")}`);
+        return;
+      }
+    } catch { /* ignore */ }
+  }
+
+  // Check 3: Uncommitted changes that may need review
+  try {
+    const status = execSync("git status --porcelain 2>/dev/null", { encoding: "utf8" }).trim();
+    if (status) {
+      const lineCount = status.split("\n").length;
+      // Only block for large uncommitted changes
+      if (lineCount >= 10) {
+        block(`${lineCount} uncommitted file changes detected — consider reviewing before stopping`);
+        return;
+      }
+    }
+  } catch {
+    // Not in a git repo — skip this check
+  }
+
+  allow("No active reviews or significant uncommitted changes");
+}
+
+main();

--- a/plugins/codex-review-core/test/codex-review.test.mjs
+++ b/plugins/codex-review-core/test/codex-review.test.mjs
@@ -11,7 +11,7 @@ import { describe, it, before, after, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import {
-  readFileSync, writeFileSync, existsSync, mkdirSync, rmSync, symlinkSync,
+  readFileSync, writeFileSync, existsSync, mkdirSync, rmSync,
 } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -19,7 +19,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI = resolve(__dirname, "../bin/codex-review.mjs");
 const FAKE_DIR = __dirname;
-const PATH_WITH_FAKE = `${FAKE_DIR}:${process.env.PATH}`;
+const FAKE_CODEX = resolve(FAKE_DIR, "fake-codex.mjs");
 const TEST_DIR = resolve(__dirname, ".test-tmp");
 
 let sessionCounter = 0;
@@ -28,7 +28,8 @@ function newSid() { return `test_${Date.now()}_${++sessionCounter}`; }
 function cli(args, opts = {}) {
   const env = {
     ...process.env,
-    PATH: PATH_WITH_FAKE,
+    CODEX_BINARY: FAKE_CODEX,
+    CODEX_REVIEW_NO_BROKER: "1",
     FAKE_TURN_DELAY_MS: String(opts.turnDelay ?? 100),
     FAKE_TURN_TEXT: opts.turnText ?? "Test output.\n\n[VERDICT] - APPROVE",
     ...(opts.turnFail ? { FAKE_TURN_FAIL: opts.turnFail } : {}),
@@ -51,8 +52,6 @@ function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
 // ---- Setup ----
 
 before(() => {
-  const link = resolve(FAKE_DIR, "codex");
-  if (!existsSync(link)) symlinkSync(resolve(FAKE_DIR, "fake-codex.sh"), link);
   mkdirSync(TEST_DIR, { recursive: true });
 });
 

--- a/plugins/codex-review-rules/.claude-plugin/plugin.json
+++ b/plugins/codex-review-rules/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-review-rules",
   "description": "Optional rules for Codex-powered plan validation and code review workflows (requires codex-review-core)",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "sanghyun-io",
     "email": "ppkimsanh@gmail.com"


### PR DESCRIPTION
## Summary

- **Structured Output Schema**: JSON Schema (`review-output.schema.json`) for machine-readable review results (verdict, findings with severity/confidence, metadata)
- **Broker Architecture**: Persistent TCP broker (`broker.mjs`) that holds a single codex app-server connection and serializes concurrent worker access, eliminating per-turn spawn overhead (~2-3s saved per call). Falls back to direct `AppServerClient` when unavailable.
- **Session Lifecycle Hooks**: `SessionStart` exports session metadata; `SessionEnd` kills running workers, shuts down broker, and cleans temp files
- **Scope Estimation**: `codex-review scope` command measures git diff size and recommends foreground/background execution mode based on configurable thresholds
- **Stop Gate**: Quality gate hook (`stop-gate.mjs`) that blocks session termination when active workers, incomplete sessions, or large uncommitted changes are detected
- **CODEX_BINARY env**: Custom codex binary path support — fixes Windows test compatibility where Unix symlinks don't work with `cmd /c`

## Test plan

- [x] All 12 tests pass (`node --test plugins/codex-review-core/test/codex-review.test.mjs`)
- [x] Tests use `CODEX_BINARY` + `CODEX_REVIEW_NO_BROKER` for cross-platform fake-codex injection
- [ ] Manual: verify `codex-review scope` outputs correct JSON with diff stats
- [ ] Manual: verify broker starts on first worker connection and persists across turns
- [ ] Manual: verify stop-gate blocks when active reviews exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)