### PR TITLE
feat(rules): auto-activate via CLAUDE.md marker block (v1.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "sanghyun-io's Claude Code plugins",
-    "version": "1.2.0"
+    "version": "1.3.0"
   },
   "plugins": [
     {
@@ -23,7 +23,7 @@
       "name": "codex-review-rules",
       "source": "./plugins/codex-review-rules",
       "description": "Optional rules for Codex-powered iterative code review workflows (requires codex-review-core)",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": { "name": "sanghyun-io" },
       "homepage": "https://github.com/sanghyun-io/codex-app-server-plugin",
       "license": "MIT",

--- a/README.md
+++ b/README.md
@@ -119,16 +119,20 @@ Installs review workflow rules that instruct Claude to automatically offer itera
 | `codex-session-ops.md` | `~/.claude/rules/` | Session list / cancel / readout |
 | `codex-delegation.md` | `~/.claude/rules/` | Natural language intent router |
 
-After installation, add to your `~/.claude/CLAUDE.md`:
+Rules are **auto-activated** during installation: the install script appends a marked block to `~/.claude/CLAUDE.md`:
 
 ```
+<!-- @codex-review-rules:begin -->
 @~/.claude/rules/review-protocol.md
 @~/.claude/rules/codex-delegation.md
 @~/.claude/rules/codex-code-review.md
 @~/.claude/rules/codex-red-review.md
 @~/.claude/rules/codex-delegate.md
 @~/.claude/rules/codex-session-ops.md
+<!-- @codex-review-rules:end -->
 ```
+
+The original `CLAUDE.md` is backed up to `CLAUDE.md.bak`. Re-running the installer is idempotent (the block is skipped if the begin marker is already present). To deactivate, remove the block manually.
 
 ### Skills
 

--- a/plugins/codex-review-rules/.claude-plugin/plugin.json
+++ b/plugins/codex-review-rules/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-review-rules",
   "description": "Optional rules for Codex-powered iterative code review workflows (requires codex-review-core)",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "sanghyun-io",
     "email": "ppkimsanh@gmail.com"

--- a/plugins/codex-review-rules/scripts/install.sh
+++ b/plugins/codex-review-rules/scripts/install.sh
@@ -31,27 +31,50 @@ for rule_file in "$PLUGIN_ROOT/rules"/*.md; do
 done
 
 echo ""
+
+# Auto-activate: append @imports to ~/.claude/CLAUDE.md
+CLAUDE_MD="$HOME/.claude/CLAUDE.md"
+MARKER_BEGIN="<!-- @codex-review-rules:begin -->"
+MARKER_END="<!-- @codex-review-rules:end -->"
+
+mkdir -p "$HOME/.claude"
+
+if [ -f "$CLAUDE_MD" ] && grep -qF "$MARKER_BEGIN" "$CLAUDE_MD"; then
+  echo -e "${YELLOW}⚠️  CLAUDE.md already contains codex-review-rules block, skipping activation${NC}"
+else
+  if [ -f "$CLAUDE_MD" ]; then
+    cp "$CLAUDE_MD" "$CLAUDE_MD.bak"
+    echo -e "✓ Backed up existing CLAUDE.md → ${GREEN}CLAUDE.md.bak${NC}"
+  else
+    touch "$CLAUDE_MD"
+  fi
+
+  {
+    echo ""
+    echo "$MARKER_BEGIN"
+    echo "@~/.claude/rules/review-protocol.md"
+    echo "@~/.claude/rules/codex-delegation.md"
+    echo "@~/.claude/rules/codex-code-review.md"
+    echo "@~/.claude/rules/codex-red-review.md"
+    echo "@~/.claude/rules/codex-delegate.md"
+    echo "@~/.claude/rules/codex-session-ops.md"
+    echo "$MARKER_END"
+  } >> "$CLAUDE_MD"
+
+  echo -e "✓ Activated rules in ${GREEN}~/.claude/CLAUDE.md${NC}"
+fi
+
+echo ""
 echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${GREEN}✓ Installation complete! ${INSTALLED_COUNT} rule file(s) installed${NC}"
 echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo ""
-echo -e "${BLUE}💡 Add to your CLAUDE.md to activate rules:${NC}"
-echo ""
-echo "   @~/.claude/rules/review-protocol.md"
-echo "   @~/.claude/rules/codex-delegation.md"
-echo "   @~/.claude/rules/codex-code-review.md"
-echo "   @~/.claude/rules/codex-red-review.md"
-echo "   @~/.claude/rules/codex-delegate.md"
-echo "   @~/.claude/rules/codex-session-ops.md"
-echo ""
-echo -e "${YELLOW}   Tip:${NC} review-protocol + codex-delegation are the two you need"
-echo -e "${YELLOW}        for the natural language router to work.${NC}"
-echo -e "${YELLOW}        The other four are the individual workflows — import only${NC}"
-echo -e "${YELLOW}        the ones you want active.${NC}"
 echo ""
 echo -e "${BLUE}📚 Next:${NC}"
 echo "   /codex-review-rules:code-review   — iterative code review"
 echo "   /codex-review-rules:red-review    — adversarial security review"
 echo "   /codex-review-rules:delegate ...  — delegate a coding task"
 echo "   /codex-review-rules:sessions      — list all Codex sessions"
+echo ""
+echo -e "${YELLOW}💡 Rules are auto-activated via markers in ~/.claude/CLAUDE.md${NC}"
+echo -e "${YELLOW}   To deactivate: remove the codex-review-rules block or run uninstall${NC}"
 echo ""


### PR DESCRIPTION
## Summary

- `plugins/codex-review-rules/scripts/install.sh` now auto-appends a marker-delimited block of `@imports` to `~/.claude/CLAUDE.md` so the six rules become active immediately after install
- Existing `CLAUDE.md` is backed up to `CLAUDE.md.bak`
- Idempotent: re-running the installer detects the `<!-- @codex-review-rules:begin -->` marker and skips
- Version bump: `codex-review-rules` 1.2.0 → 1.3.0, marketplace 1.2.0 → 1.3.0 (core unchanged)

## Why

Copying rule files to `~/.claude/rules/` is not enough — Claude Code does not auto-scan that directory. Activation requires `@` imports inside a loaded `CLAUDE.md`. The previous setup asked users to paste the imports manually, which created friction.

## Marker block format

```markdown
<!-- @codex-review-rules:begin -->
@~/.claude/rules/review-protocol.md
@~/.claude/rules/codex-delegation.md
@~/.claude/rules/codex-code-review.md
@~/.claude/rules/codex-red-review.md
@~/.claude/rules/codex-delegate.md
@~/.claude/rules/codex-session-ops.md
<!-- @codex-review-rules:end -->
```

## Test plan

- [ ] Fresh install on a machine without `~/.claude/CLAUDE.md` → file created with marker block
- [ ] Install over existing `CLAUDE.md` → `.bak` created, block appended at the end
- [ ] Re-run installer → skip message shown, no duplicate block
- [ ] Remove the block manually → re-run installer → block appended again

🤖 Generated with [Claude Code](https://claude.com/claude-code)