### PR TITLE
feat: add --stdin flag to eliminate Write tool permission prompts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "sanghyun-io's Claude Code plugins",
-    "version": "1.3.0"
+    "version": "1.4.0"
   },
   "plugins": [
     {
       "name": "codex-review-core",
       "source": "./plugins/codex-review-core",
       "description": "Codex App Server wrapper for Claude Code — installs the codex-review CLI binary",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": { "name": "sanghyun-io" },
       "homepage": "https://github.com/sanghyun-io/codex-app-server-plugin",
       "license": "MIT",
@@ -23,7 +23,7 @@
       "name": "codex-review-rules",
       "source": "./plugins/codex-review-rules",
       "description": "Optional rules for Codex-powered iterative code review workflows (requires codex-review-core)",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "author": { "name": "sanghyun-io" },
       "homepage": "https://github.com/sanghyun-io/codex-app-server-plugin",
       "license": "MIT",

--- a/plugins/codex-review-core/.claude-plugin/plugin.json
+++ b/plugins/codex-review-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-review-core",
   "description": "Codex App Server wrapper for Claude Code — installs the codex-review CLI binary",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "sanghyun-io",
     "email": "ppkimsanh@gmail.com"

--- a/plugins/codex-review-core/bin/codex-review.mjs
+++ b/plugins/codex-review-core/bin/codex-review.mjs
@@ -14,6 +14,7 @@
  *   --model <MODEL>       Model override (default: gpt-5.4, env: CODEX_REVIEW_MODEL)
  *   --timeout <MS>        Hard timeout in ms (default: 1800000, env: CODEX_REVIEW_TIMEOUT)
  *   --foreground          Run synchronously (v1 compat, no background worker)
+ *   --stdin               Read prompt from stdin and write to <prompt-file> (avoids Write tool permission)
  *
  * Exit codes:
  *   0 = success / completed
@@ -706,6 +707,16 @@ function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => { data += chunk; });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Logging
 // ---------------------------------------------------------------------------
@@ -925,6 +936,17 @@ async function cmdStart(parsed) {
     console.error("Error: start requires <prompt-file> <output-file>");
     process.exit(6);
   }
+  if (parsed.stdin) {
+    const promptFile = resolve(parsed.positional[0]);
+    const promptText = await readStdin();
+    if (!promptText.trim()) {
+      console.error("Error: empty prompt received from stdin");
+      process.exit(6);
+    }
+    mkdirSync(dirname(promptFile), { recursive: true });
+    writeFileSync(promptFile, promptText, "utf8");
+    log(`Prompt written from stdin (${promptText.length} chars) → ${promptFile}`);
+  }
   spawnWorker(parsed);
 }
 
@@ -943,6 +965,18 @@ async function cmdFollowUp(parsed) {
   if (!state?.threadId) {
     log(`No active session found for ${parsed.sessionId}. Run 'start' first.`);
     process.exit(4);
+  }
+
+  if (parsed.stdin) {
+    const promptFile = resolve(parsed.positional[0]);
+    const promptText = await readStdin();
+    if (!promptText.trim()) {
+      console.error("Error: empty prompt received from stdin");
+      process.exit(6);
+    }
+    mkdirSync(dirname(promptFile), { recursive: true });
+    writeFileSync(promptFile, promptText, "utf8");
+    log(`Prompt written from stdin (${promptText.length} chars) → ${promptFile}`);
   }
 
   spawnWorker(parsed);
@@ -1236,6 +1270,7 @@ Options:
   --model <MODEL>       Model to use (default: gpt-5.4, env: CODEX_REVIEW_MODEL)
   --timeout <MS>        Hard timeout in ms (default: 1800000, env: CODEX_REVIEW_TIMEOUT)
   --foreground          Run synchronously (v1 compat)
+  --stdin               Read prompt from stdin, write to <prompt-file>
 
 Exit codes:
   0 = success / completed
@@ -1272,6 +1307,7 @@ function parseArgs(argv) {
   let timeout = null;
   let nonce = null;
   let foreground = false;
+  let stdin = false;
   const positional = [];
 
   for (let i = 1; i < raw.length; i++) {
@@ -1287,6 +1323,8 @@ function parseArgs(argv) {
       nonce = raw[++i];
     } else if (raw[i] === "--foreground") {
       foreground = true;
+    } else if (raw[i] === "--stdin") {
+      stdin = true;
     } else if (!raw[i].startsWith("--")) {
       positional.push(raw[i]);
     }
@@ -1304,6 +1342,7 @@ function parseArgs(argv) {
       timeout: DEFAULT_HARD_TIMEOUT_MS,
       nonce,
       foreground,
+      stdin,
       isWorker,
     };
   }
@@ -1334,6 +1373,7 @@ function parseArgs(argv) {
     timeout: resolvedTimeout,
     nonce,
     foreground,
+    stdin,
     isWorker,
   };
 }

--- a/plugins/codex-review-rules/.claude-plugin/plugin.json
+++ b/plugins/codex-review-rules/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-review-rules",
   "description": "Optional rules for Codex-powered iterative code review workflows (requires codex-review-core)",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "sanghyun-io",
     "email": "ppkimsanh@gmail.com"

--- a/plugins/codex-review-rules/rules/codex-delegate.md
+++ b/plugins/codex-review-rules/rules/codex-delegate.md
@@ -72,25 +72,23 @@ Codex에게 자율적 작업을 위임하되, 실제 파일 변경은 Claude가 
 
 ## Turn 1: 초기 프롬프트
 
-### Step 1: 프롬프트 파일 작성
+### Step 1: 프롬프트 전달 + codex-review start 실행
 
-Write 도구로 파일 작성:
-- 경로: `{HOME}/.claude/tmp/dg_{SID}_t1_prompt.txt`
-- 내용: 아래 **Delegate Prompt Template**의 플레이스홀더 치환본
-
-### Step 2: codex-review start 실행
-
-review-protocol.md의 **PHASE 1 Step 2**를 따르되 세션 이름은 `dg_{SID}`:
+`--stdin` heredoc으로 프롬프트를 전달한다 (Write 도구 불필요).
+세션 이름은 `dg_{SID}`:
 
 ```bash
-node "{HOME_LITERAL}/.claude/bin/codex-review.mjs" start "{HOME_LITERAL}/.claude/tmp/dg_{SID}_t1_prompt.txt" "{HOME_LITERAL}/.claude/tmp/dg_{SID}_t1_output.txt" --session "dg_{SID}" --review-dir "{HOME_LITERAL}/.claude/tmp"; echo "EXIT_CODE: $?"
+node "{HOME_LITERAL}/.claude/bin/codex-review.mjs" start --stdin "{HOME_LITERAL}/.claude/tmp/dg_{SID}_t1_prompt.txt" "{HOME_LITERAL}/.claude/tmp/dg_{SID}_t1_output.txt" --session "dg_{SID}" --review-dir "{HOME_LITERAL}/.claude/tmp" <<'PROMPT_EOF'
+{치환 완료된 프롬프트 전문}
+PROMPT_EOF
+echo "EXIT_CODE: $?"
 ```
 
-### Step 3: 폴링
+### Step 2: 폴링
 
-review-protocol.md의 **PHASE 1 Step 3**과 동일 (status → 30초 간격, 2분 초과 시 AskUserQuestion).
+review-protocol.md의 **PHASE 1 Step 2**와 동일 (status → 30초 간격, 2분 초과 시 AskUserQuestion).
 
-### Step 4: 결과 수집 및 해석
+### Step 3: 결과 수집 및 해석
 
 `dg_{SID}_t1_output.txt` 읽기. Codex 응답은 다음 중 한 형식으로 온다:
 
@@ -117,21 +115,20 @@ review-protocol.md의 **PHASE 1 Step 3**과 동일 (status → 30초 간격, 2�
 | Observations | 예상과 다른 결과, 에러, 추가로 발견한 문제 |
 | Blockers | Codex 판단이 필요한 불확실한 부분 |
 
-### Step 2: Follow-up 프롬프트 작성
+### Step 2: 프롬프트 전달 + codex-review follow-up 실행
 
-Write 도구:
-- 경로: `{HOME}/.claude/tmp/dg_{SID}_t{N}_prompt.txt`
-- 내용: **Delegate Follow-up Template** (증분 정보만)
+`--stdin` heredoc으로 follow-up 프롬프트를 전달한다:
+
+```bash
+node "{HOME_LITERAL}/.claude/bin/codex-review.mjs" follow-up --stdin "{HOME_LITERAL}/.claude/tmp/dg_{SID}_t{N}_prompt.txt" "{HOME_LITERAL}/.claude/tmp/dg_{SID}_t{N}_output.txt" --session "dg_{SID}" --review-dir "{HOME_LITERAL}/.claude/tmp" <<'PROMPT_EOF'
+{치환 완료된 follow-up 프롬프트 전문}
+PROMPT_EOF
+echo "EXIT_CODE: $?"
+```
 
 > **⛔ 금지**: 이전 Turn의 프롬프트/컨텍스트 재전송. Thread가 기억하고 있다.
 
-### Step 3: codex-review follow-up 실행
-
-```bash
-node "{HOME_LITERAL}/.claude/bin/codex-review.mjs" follow-up "{HOME_LITERAL}/.claude/tmp/dg_{SID}_t{N}_prompt.txt" "{HOME_LITERAL}/.claude/tmp/dg_{SID}_t{N}_output.txt" --session "dg_{SID}" --review-dir "{HOME_LITERAL}/.claude/tmp"; echo "EXIT_CODE: $?"
-```
-
-### Step 4: 폴링 + 결과 처리
+### Step 3: 폴링 + 결과 처리
 
 Turn 1과 동일. Codex 응답을 해석하여 다음 행동을 결정한다.
 

--- a/plugins/codex-review-rules/rules/review-protocol.md
+++ b/plugins/codex-review-rules/rules/review-protocol.md
@@ -57,9 +57,8 @@ SID=$(date +%s)_$$ && REVIEW_DIR="{HOME_LITERAL}/.claude/tmp" && mkdir -p "$REVI
 > 모든 출력 파일에 `{SID}`를 반드시 포함한다.
 >
 > **⛔ Windows 경로 규칙**:
-> - Write 도구: `{HOME}/.claude/tmp/cr_{SID}_*.txt` (절대 경로, `{HOME}`은 런타임에 해석)
 > - Bash/Git Bash: **`{HOME_LITERAL}/.claude/tmp/cr_{SID}_*.txt`** (리터럴 경로 사용)
-> - **절대로 `/tmp/`를 사용하지 않는다** (Windows에서 Write 도구와 Git Bash의 /tmp/ 경로가 불일치)
+> - **절대로 `/tmp/`를 사용하지 않는다** (Windows에서 Git Bash의 /tmp/ 경로가 시스템과 불일치)
 > - **절대로 Bash 도구에서 `$HOME`을 직접 사용하지 않는다** (확장 실패 가능성)
 
 #### 파일 규칙
@@ -69,9 +68,11 @@ SID=$(date +%s)_$$ && REVIEW_DIR="{HOME_LITERAL}/.claude/tmp" && mkdir -p "$REVI
 
 **파일이 필요한 이유**:
 - Git Bash 파이프 경유 시 한글 인코딩 깨짐 방지
-- Bash 도구 30000자 truncation 방지
 - **동시 세션 간 파일 충돌 방지**
 - 프롬프트 이력 보존 (디버깅 및 재실행 용이)
+
+> **`--stdin` 모드**: 프롬프트를 heredoc으로 CLI에 전달하면 CLI가 내부적으로 파일을 작성한다.
+> Write 도구 호출이 불필요하므로 **사용자 인가 없이** 프롬프트 파일이 생성된다.
 
 **파일 네이밍 규칙** (코드 리뷰):
 
@@ -86,7 +87,7 @@ SID=$(date +%s)_$$ && REVIEW_DIR="{HOME_LITERAL}/.claude/tmp" && mkdir -p "$REVI
 | Worker 로그 | `{REVIEW_DIR}/cr_{SID}_worker.log` |
 
 > `{SID}`는 세션 ID, `{REVIEW_DIR}`은 `{HOME_LITERAL}/.claude/tmp`으로 치환한다 (`{HOME_LITERAL}`은 세션 초기화에서 확인한 리터럴 경로).
-> Write 도구 사용 시에는 `{HOME}/.claude/tmp/cr_{SID}_*.txt` 형태의 절대 경로를 사용한다.
+> 프롬프트 파일은 `--stdin` 플래그를 사용하여 CLI가 직접 작성한다 (Write 도구 불필요).
 
 ---
 
@@ -111,36 +112,33 @@ Engineering standards for this review:
 `codex-review start` 명령으로 새 Thread를 생성하고 첫 Turn을 전송한다.
 프롬프트는 아래 **Code Review Prompt Template**의 플레이스홀더를 치환하여 사용한다.
 
-#### Step 1: 프롬프트 파일 생성 (필수)
+#### Step 1: 프롬프트 전달 + codex-review start 실행 (단일 Bash 호출)
 
-**반드시** Write 도구로 프롬프트를 파일에 저장한다:
+`--stdin` 플래그를 사용하여 **프롬프트를 heredoc으로 전달**한다.
+CLI가 내부적으로 프롬프트 파일을 작성하므로 Write 도구 호출이 필요 없다.
 
-- 파일 경로: `{REVIEW_DIR}/cr_{SID}_r1_prompt.txt`
-  - Write 도구: `{HOME}/.claude/tmp/cr_{SID}_r1_prompt.txt`
-- 내용: Code Review Prompt Template의 플레이스홀더 치환 완료본
-
-> **⛔ 필수**: 이 단계를 건너뛰고 프롬프트를 인라인으로 전달하는 것을 금지한다.
-
-#### Step 2: codex-review start 실행 (비동기)
-
-`codex-review.mjs` v2의 `start` 명령은 **백그라운드 워커를 spawn하고 즉시 반환**한다.
+Code Review Prompt Template의 플레이스홀더를 치환한 완료본을 heredoc 본문으로 넣는다.
 `{HOME_LITERAL}`은 세션 초기화 Step A에서 확인한 리터럴 경로로 치환한다:
 
 ```bash
-node "{HOME_LITERAL}/.claude/bin/codex-review.mjs" start "{HOME_LITERAL}/.claude/tmp/cr_{SID}_r1_prompt.txt" "{HOME_LITERAL}/.claude/tmp/cr_{SID}_r1_output.txt" --session "cr_{SID}" --review-dir "{HOME_LITERAL}/.claude/tmp"; echo "EXIT_CODE: $?"
+node "{HOME_LITERAL}/.claude/bin/codex-review.mjs" start --stdin "{HOME_LITERAL}/.claude/tmp/cr_{SID}_r1_prompt.txt" "{HOME_LITERAL}/.claude/tmp/cr_{SID}_r1_output.txt" --session "cr_{SID}" --review-dir "{HOME_LITERAL}/.claude/tmp" <<'PROMPT_EOF'
+{치환 완료된 프롬프트 전문}
+PROMPT_EOF
+echo "EXIT_CODE: $?"
 ```
 
-> **핵심 (v2 변경사항)**:
+> **핵심**:
+> - `--stdin`으로 프롬프트를 stdin에서 읽어 `<prompt-file>`에 자동 저장 → **Write 도구 인가 불필요**
 > - `start` 명령은 **즉시 반환** (exit 0). 실제 Codex 호출은 백그라운드 워커가 처리
 > - 워커는 진행 상황을 `cr_{SID}_progress.json`에 3초 간격으로 기록
-> - 결과 확인은 **Step 3 (폴링)**으로 진행
+> - 결과 확인은 **Step 2 (폴링)**으로 진행
 > - `--session`과 `--review-dir`는 필수 인자
-> - `; echo "EXIT_CODE: $?"`로 exit code 확인 (반드시 `;`로 분리)
+> - heredoc 종료 후 `echo "EXIT_CODE: $?"`로 exit code 확인
 >
 > **⛔ `$HOME` 직접 사용 금지**: Bash 도구 호출마다 `$HOME`이 빈 문자열로 확장될 수 있다.
 > 반드시 세션 초기화에서 확인한 `{HOME_LITERAL}` 리터럴 경로를 사용한다.
 
-#### Step 3: 진행 상황 폴링 (status)
+#### Step 2: 진행 상황 폴링 (status)
 
 `start`가 exit 0을 반환하면, **30초 간격**으로 `status` 명령을 호출하여 진행 상황을 확인한다:
 
@@ -152,9 +150,9 @@ node "{HOME_LITERAL}/.claude/bin/codex-review.mjs" status --session "cr_{SID}" -
 
 | Exit Code | 상태 | 처리 |
 |:---------:|------|------|
-| 0 | `completed` | **Step 4로 진행** — 출력 파일 읽기 |
+| 0 | `completed` | **Step 3으로 진행** — 출력 파일 읽기 |
 | 7 | `running` / `initializing` / `queued` | **30초 후 재폴링** (아래 사용자 알림 임계치 참조) |
-| 5 | `timeout_partial` | 부분 출력 저장됨 — Step 4로 진행 (출력 파일 읽기) |
+| 5 | `timeout_partial` | 부분 출력 저장됨 — Step 3으로 진행 (출력 파일 읽기) |
 | 8 | `cancelled` | 취소됨 — 부분 출력이 있으면 읽기 |
 | 6 | `crashed` / `failed` | 에러 처리 섹션 참조 |
 | 1-4 | 기타 에러 | 에러 처리 섹션 참조 |
@@ -198,7 +196,7 @@ node "{HOME_LITERAL}/.claude/bin/codex-review.mjs" status --session "cr_{SID}" -
 node "{HOME_LITERAL}/.claude/bin/codex-review.mjs" cancel --session "cr_{SID}" --review-dir "{HOME_LITERAL}/.claude/tmp"
 ```
 
-#### Step 4: 결과 수집
+#### Step 3: 결과 수집
 
 status exit 0 (completed) 반환 후, Read 도구로 출력 파일 읽기:
 
@@ -218,13 +216,9 @@ Round 2+ 증분 리뷰 시 사용한다.
 - Round 1 완료 후 사용자가 이슈를 수정하고 Round 2+로 진입할 때
 - Round N에서 다음 Round N+1로 진행할 때
 
-#### Step 1: Follow-up 프롬프트 파일 생성
+#### Step 1: 프롬프트 전달 + codex-review follow-up 실행 (단일 Bash 호출)
 
-Write 도구로 follow-up 프롬프트를 파일에 저장한다:
-
-- 파일 경로: `{REVIEW_DIR}/cr_{SID}_r{N}_prompt.txt` (N = 라운드 번호, 2부터)
-  - Write 도구: `{HOME}/.claude/tmp/cr_{SID}_r{N}_prompt.txt`
-- 내용: **Code Review Prompt Template**의 플레이스홀더를 치환한 완료본 (증분 diff + 히스토리 포함)
+PHASE 1과 동일하게 `--stdin` heredoc으로 프롬프트를 전달한다.
 
 **Follow-up 컨텐츠 구성 규칙**:
 
@@ -238,23 +232,25 @@ Write 도구로 follow-up 프롬프트를 파일에 저장한다:
 > **⛔ 전체 diff 재전송 금지**: follow-up에서는 증분 diff만 전송한다.
 > Thread가 이전 Turn의 전체 컨텍스트를 기억하고 있으므로, 이번 라운드에서 변경된 부분만 보내면 된다.
 
-#### Step 2: codex-review follow-up 실행 (비동기)
-
 ```bash
-node "{HOME_LITERAL}/.claude/bin/codex-review.mjs" follow-up "{HOME_LITERAL}/.claude/tmp/cr_{SID}_r{N}_prompt.txt" "{HOME_LITERAL}/.claude/tmp/cr_{SID}_r{N}_output.txt" --session "cr_{SID}" --review-dir "{HOME_LITERAL}/.claude/tmp"; echo "EXIT_CODE: $?"
+node "{HOME_LITERAL}/.claude/bin/codex-review.mjs" follow-up --stdin "{HOME_LITERAL}/.claude/tmp/cr_{SID}_r{N}_prompt.txt" "{HOME_LITERAL}/.claude/tmp/cr_{SID}_r{N}_output.txt" --session "cr_{SID}" --review-dir "{HOME_LITERAL}/.claude/tmp" <<'PROMPT_EOF'
+{치환 완료된 follow-up 프롬프트 전문}
+PROMPT_EOF
+echo "EXIT_CODE: $?"
 ```
 
-> **동작 원리**: `follow-up` 명령은 state 파일에서 threadId를 읽어 기존 Thread를 resume한 뒤,
+> **동작 원리**: `follow-up --stdin`은 stdin에서 프롬프트를 읽어 파일에 저장한 뒤,
+> state 파일에서 threadId를 읽어 기존 Thread를 resume하고,
 > 백그라운드 워커로 새 Turn을 생성한다. **즉시 반환** (exit 0).
 
-#### Step 3: 진행 상황 폴링 (status)
+#### Step 2: 진행 상황 폴링 (status)
 
-PHASE 1 Step 3과 **동일한 폴링 패턴**을 사용한다:
+PHASE 1 Step 2와 **동일한 폴링 패턴**을 사용한다:
 - 30초 간격으로 `status` 명령 호출
 - 2분 초과 시 AskUserQuestion으로 사용자 알림
 - 완료 시 출력 파일 읽기
 
-#### Step 4: 결과 수집
+#### Step 3: 결과 수집
 
 Read 도구로 `{HOME}/.claude/tmp/cr_{SID}_r{N}_output.txt` 읽기.
 


### PR DESCRIPTION
Codex review/delegate workflows required the Write tool to create prompt
files before each CLI invocation, triggering user authorization on every
call — even in bypass mode. This broke development flow.

The --stdin flag lets the CLI read prompt content from stdin (via heredoc)
and write the prompt file internally, removing the need for Write tool
calls entirely. Updated review-protocol.md and codex-delegate.md to use
the new single-Bash-call pattern.

https://claude.ai/code/session_01Af6xKecPc8yLNH71yKdGWy