### PR TITLE
fix(core): isolate turn notifications in broker (v1.3.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "sanghyun-io's Claude Code plugins",
-    "version": "1.4.0"
+    "version": "1.4.1"
   },
   "plugins": [
     {
       "name": "codex-review-core",
       "source": "./plugins/codex-review-core",
       "description": "Codex App Server wrapper for Claude Code — installs the codex-review CLI binary",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "author": { "name": "sanghyun-io" },
       "homepage": "https://github.com/sanghyun-io/codex-app-server-plugin",
       "license": "MIT",

--- a/plugins/codex-review-core/.claude-plugin/plugin.json
+++ b/plugins/codex-review-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-review-core",
   "description": "Codex App Server wrapper for Claude Code — installs the codex-review CLI binary",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "sanghyun-io",
     "email": "ppkimsanh@gmail.com"

--- a/plugins/codex-review-core/bin/broker.mjs
+++ b/plugins/codex-review-core/bin/broker.mjs
@@ -26,6 +26,18 @@
  *     { "type": "pong" }
  *     { "type": "error", "message": "..." }
  *
+ * Turn serialization:
+ *   The upstream codex app-server streams agent deltas and turn events on a
+ *   single stdin/stdout pipe without a threadId tag, so two concurrent
+ *   `turn/start` requests would produce interleaved notifications that the
+ *   broker cannot disambiguate. To prevent cross-turn contamination, the
+ *   broker serializes `turn/start`: one turn owns the notification stream at
+ *   a time, later requests queue until the previous turn emits a terminal
+ *   event (`turn/completed` / `turn/failed` / `turn/cancelled`) or the
+ *   client disconnects. Notifications whose method matches `item/*`,
+ *   `turn/*`, or `error` are routed only to the active turn's socket;
+ *   everything else goes through the normal subscribe fan-out.
+ *
  * Lifecycle:
  *   - Starts on first worker connection (via ensureBroker() in codex-review.mjs)
  *   - Auto-shuts down after IDLE_TIMEOUT_MS of no active connections
@@ -50,8 +62,24 @@ import { resolve } from "node:path";
 const HOME = process.env.HOME || process.env.USERPROFILE || "";
 const TMP_DIR = resolve(HOME, ".claude", "tmp");
 const PORT_FILE = resolve(TMP_DIR, "broker.port");
-const IDLE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
-const INIT_TIMEOUT_MS = 30_000;          // 30s for codex init
+const IDLE_TIMEOUT_MS = 10 * 60 * 1000;      // 10 minutes
+const INIT_TIMEOUT_MS = 30_000;              // 30s for codex init
+const DEFAULT_TURN_TIMEOUT_MS = 1_800_000;   // 30 min (matches codex-review default)
+const TURN_SAFETY_BUFFER_MS = 15_000;        // grace window beyond client timeout
+
+const TURN_SCOPED_PREFIXES = ["item/", "turn/"];
+const TURN_SCOPED_METHODS = new Set(["error"]);
+const TURN_TERMINAL_METHODS = new Set([
+  "turn/completed",
+  "turn/failed",
+  "turn/cancelled",
+]);
+
+function isTurnScopedMethod(method) {
+  if (!method) return false;
+  if (TURN_SCOPED_METHODS.has(method)) return true;
+  return TURN_SCOPED_PREFIXES.some((p) => method.startsWith(p));
+}
 
 // ---------------------------------------------------------------------------
 // Logging
@@ -71,10 +99,14 @@ class AppServerConnection {
     this.rl = null;
     this.msgId = 0;
     this.pendingRequests = new Map();
-    this.subscribers = new Set(); // Set of {socket, methods}
+    this.subscribers = new Set();         // Set of { socket, methods }
     this.initialized = false;
     this.serverInfo = null;
     this.account = null;
+
+    // Turn serialization state
+    this.activeTurn = null;               // { socket, startedAt, safetyTimer }
+    this.turnWaiters = [];                // FIFO queue of { socket, timeoutMs, resolve }
   }
 
   nextId() { return ++this.msgId; }
@@ -85,12 +117,14 @@ class AppServerConnection {
       if (customBin) {
         this.proc = spawn(process.execPath, [customBin], {
           stdio: ["pipe", "pipe", "pipe"],
+          windowsHide: true,
         });
       } else {
         const isWin = process.platform === "win32";
         this.proc = isWin
           ? spawn("cmd", ["/c", "codex", "app-server"], {
               stdio: ["pipe", "pipe", "pipe"],
+              windowsHide: true,
             })
           : spawn("codex", ["app-server"], {
               stdio: ["pipe", "pipe", "pipe"],
@@ -124,24 +158,44 @@ class AppServerConnection {
   _handleMessage(msg) {
     // Response to a pending request
     if (msg.id != null && this.pendingRequests.has(msg.id)) {
-      const { resolve: res, reject: rej, clientId } = this.pendingRequests.get(msg.id);
+      const { resolve: res, reject: rej } = this.pendingRequests.get(msg.id);
       this.pendingRequests.delete(msg.id);
       msg.error ? rej(msg.error) : res(msg.result);
       return;
     }
 
-    // Notification from app-server → forward to subscribers
-    if (msg.method) {
-      for (const sub of this.subscribers) {
-        if (sub.methods.includes("*") || sub.methods.includes(msg.method)) {
-          try {
-            sub.socket.write(JSON.stringify({
-              type: "notification",
-              method: msg.method,
-              params: msg.params,
-            }) + "\n");
-          } catch { /* client disconnected */ }
-        }
+    if (!msg.method) return;
+
+    // Turn-scoped notifications must never leak between concurrent turns.
+    // Route them only to the socket that currently owns the turn; if no turn
+    // is active (e.g. trailing notifications arriving after a cancel), drop.
+    if (isTurnScopedMethod(msg.method)) {
+      const sock = this.activeTurn?.socket;
+      if (sock) {
+        try {
+          sock.write(JSON.stringify({
+            type: "notification",
+            method: msg.method,
+            params: msg.params,
+          }) + "\n");
+        } catch { /* client disconnected */ }
+      }
+      if (TURN_TERMINAL_METHODS.has(msg.method)) {
+        this._releaseTurn(`terminal:${msg.method}`);
+      }
+      return;
+    }
+
+    // Non-turn notification → forward via subscribe fan-out
+    for (const sub of this.subscribers) {
+      if (sub.methods.includes("*") || sub.methods.includes(msg.method)) {
+        try {
+          sub.socket.write(JSON.stringify({
+            type: "notification",
+            method: msg.method,
+            params: msg.params,
+          }) + "\n");
+        } catch { /* client disconnected */ }
       }
     }
   }
@@ -204,7 +258,80 @@ class AppServerConnection {
     this.subscribers.delete(sub);
   }
 
+  // -- Turn serialization --
+
+  /**
+   * Acquire exclusive ownership of the upstream notification stream for a
+   * `turn/start` request. Resolves immediately if no turn is active,
+   * otherwise queues FIFO until the previous turn releases.
+   */
+  acquireTurn(socket, timeoutMs) {
+    return new Promise((resolve) => {
+      const task = { socket, timeoutMs: timeoutMs || DEFAULT_TURN_TIMEOUT_MS, resolve };
+      if (!this.activeTurn) {
+        this._grantTurn(task);
+      } else {
+        this.turnWaiters.push(task);
+        log(`Turn queued (queue depth: ${this.turnWaiters.length})`);
+      }
+    });
+  }
+
+  _grantTurn(task) {
+    const safetyMs = task.timeoutMs + TURN_SAFETY_BUFFER_MS;
+    const safetyTimer = setTimeout(() => {
+      log(`Turn safety timeout (${safetyMs}ms) — force-releasing`);
+      this._releaseTurn("safety-timeout");
+    }, safetyMs);
+    this.activeTurn = {
+      socket: task.socket,
+      startedAt: Date.now(),
+      safetyTimer,
+    };
+    task.resolve();
+  }
+
+  /**
+   * Release the active-turn mutex. Grants the next waiter if any. Safe to
+   * call multiple times or when no turn is active.
+   */
+  _releaseTurn(reason) {
+    if (!this.activeTurn) return;
+    if (this.activeTurn.safetyTimer) clearTimeout(this.activeTurn.safetyTimer);
+    this.activeTurn = null;
+    if (this.turnWaiters.length > 0) {
+      const next = this.turnWaiters.shift();
+      // Skip waiters whose socket has already disconnected
+      if (next.socket.destroyed) {
+        this._releaseTurn("skip-dead-waiter");
+        return;
+      }
+      log(`Turn released (${reason || "unknown"}), granting queued waiter`);
+      this._grantTurn(next);
+    } else if (reason) {
+      log(`Turn released (${reason})`);
+    }
+  }
+
+  /**
+   * Handle a socket closing: release the turn if this socket owns it, and
+   * drop it from the waiter queue.
+   */
+  onSocketClose(socket) {
+    // Drop from waiter queue
+    if (this.turnWaiters.length > 0) {
+      this.turnWaiters = this.turnWaiters.filter((w) => w.socket !== socket);
+    }
+    // Release if this socket owns the active turn
+    if (this.activeTurn?.socket === socket) {
+      this._releaseTurn("socket-closed");
+    }
+  }
+
   close() {
+    if (this.activeTurn?.safetyTimer) clearTimeout(this.activeTurn.safetyTimer);
+    this.activeTurn = null;
+    this.turnWaiters = [];
     this.pendingRequests.clear();
     this.subscribers.clear();
     if (this.rl) { this.rl.close(); this.rl = null; }
@@ -281,8 +408,25 @@ class BrokerServer {
         switch (msg.action) {
           case "request": {
             const timeoutMs = msg.timeout || INIT_TIMEOUT_MS;
-            const result = await this.appServer.request(msg.method, msg.params, timeoutMs);
-            socket.write(JSON.stringify({ type: "response", id: msg.id, result }) + "\n");
+            const isTurnStart = msg.method === "turn/start";
+            let acquired = false;
+
+            if (isTurnStart) {
+              await this.appServer.acquireTurn(socket, timeoutMs);
+              acquired = true;
+            }
+
+            try {
+              const result = await this.appServer.request(msg.method, msg.params, timeoutMs);
+              socket.write(JSON.stringify({ type: "response", id: msg.id, result }) + "\n");
+            } catch (err) {
+              if (isTurnStart && acquired && this.appServer.activeTurn?.socket === socket) {
+                // turn/start request failed before upstream streamed terminal event;
+                // release the mutex so other clients aren't blocked.
+                this.appServer._releaseTurn("turn-start-request-error");
+              }
+              throw err;
+            }
             break;
           }
 
@@ -323,21 +467,24 @@ class BrokerServer {
       }
     });
 
-    socket.on("close", () => {
+    const cleanup = () => {
       this.clients.delete(socket);
       if (subscription) {
         this.appServer.removeSubscriber(subscription);
+        subscription = null;
       }
+      this.appServer.onSocketClose(socket);
       rl.close();
+    };
+
+    socket.on("close", () => {
+      cleanup();
       log(`Client disconnected (${this.clients.size} active)`);
       this._resetIdleTimer();
     });
 
     socket.on("error", () => {
-      this.clients.delete(socket);
-      if (subscription) {
-        this.appServer.removeSubscriber(subscription);
-      }
+      cleanup();
     });
   }
 

--- a/plugins/codex-review-core/bin/codex-review.mjs
+++ b/plugins/codex-review-core/bin/codex-review.mjs
@@ -86,12 +86,14 @@ class AppServerClient {
         // Custom binary (e.g. fake-codex.mjs for testing)
         this.proc = spawn(process.execPath, [customBin], {
           stdio: ["pipe", "pipe", "pipe"],
+          windowsHide: true,
         });
       } else {
         const isWin = process.platform === "win32";
         this.proc = isWin
           ? spawn("cmd", ["/c", "codex", "app-server"], {
               stdio: ["pipe", "pipe", "pipe"],
+              windowsHide: true,
             })
           : spawn("codex", ["app-server"], {
               stdio: ["pipe", "pipe", "pipe"],
@@ -604,6 +606,7 @@ async function connectOrStartBroker() {
     detached: true,
     stdio: ["ignore", logFd, logFd],
     env: process.env,
+    windowsHide: true,
   });
   brokerProc.unref();
   closeSync(logFd);
@@ -914,6 +917,7 @@ function spawnWorker(parsed) {
     detached: true,
     stdio: ["ignore", logFd, logFd],
     env: process.env,
+    windowsHide: true,
   });
 
   // Write PID file with nonce for identity verification

--- a/plugins/codex-review-core/test/codex-review.test.mjs
+++ b/plugins/codex-review-core/test/codex-review.test.mjs
@@ -26,12 +26,16 @@ let sessionCounter = 0;
 function newSid() { return `test_${Date.now()}_${++sessionCounter}`; }
 
 function cli(args, opts = {}) {
+  const baseEnv = opts.home
+    ? { ...process.env, HOME: opts.home, USERPROFILE: opts.home }
+    : { ...process.env };
   const env = {
-    ...process.env,
+    ...baseEnv,
     CODEX_BINARY: FAKE_CODEX,
-    CODEX_REVIEW_NO_BROKER: "1",
     FAKE_TURN_DELAY_MS: String(opts.turnDelay ?? 100),
     FAKE_TURN_TEXT: opts.turnText ?? "Test output.\n\n[VERDICT] - APPROVE",
+    ...(opts.broker ? {} : { CODEX_REVIEW_NO_BROKER: "1" }),
+    ...(opts.tagThread ? { FAKE_TAG_THREAD: "1" } : {}),
     ...(opts.turnFail ? { FAKE_TURN_FAIL: opts.turnFail } : {}),
     ...(opts.authFail ? { FAKE_AUTH_FAIL: "1" } : {}),
   };
@@ -180,6 +184,131 @@ describe("error handling", () => {
     writeFileSync(prompt, "test", "utf8");
     const r = cli(["start", prompt, output, "--session", sid, "--review-dir", TEST_DIR, "--foreground"], { authFail: true });
     assert.equal(r.exit, 2);
+  });
+});
+
+describe("broker turn serialization", () => {
+  const BROKER_HOME = resolve(TEST_DIR, "broker_home");
+  const BROKER_TMP = resolve(BROKER_HOME, ".claude", "tmp");
+  const BROKER_PORT_FILE = resolve(BROKER_TMP, "broker.port");
+
+  before(() => {
+    mkdirSync(BROKER_TMP, { recursive: true });
+  });
+
+  after(() => {
+    // Kill any broker we started so it doesn't linger between runs
+    if (existsSync(BROKER_PORT_FILE)) {
+      try {
+        const data = JSON.parse(readFileSync(BROKER_PORT_FILE, "utf8"));
+        if (data?.pid) {
+          try { process.kill(data.pid, "SIGTERM"); } catch { /* already dead */ }
+        }
+      } catch { /* ignore */ }
+    }
+  });
+
+  async function pollToComplete(sid, timeoutMs = 30_000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      await sleep(300);
+      const r = cli(
+        ["status", "--session", sid, "--review-dir", TEST_DIR],
+        { broker: true, home: BROKER_HOME }
+      );
+      if (r.exit === 0) return JSON.parse(r.stdout);
+      if (![7].includes(r.exit)) throw new Error(`status exit ${r.exit}: ${r.stderr}`);
+    }
+    throw new Error(`Session ${sid} did not complete within ${timeoutMs}ms`);
+  }
+
+  it("does not mix deltas between concurrent turns", async () => {
+    // Two concurrent sessions share the same broker/upstream. Each emits
+    // deltas tagged with its threadId. If the broker routed notifications
+    // to the wrong subscriber, one session's output would contain the
+    // other's threadId tag.
+    const mkSession = (marker) => {
+      const sid = newSid();
+      const promptPath = resolve(TEST_DIR, `${sid}_p.txt`);
+      const outputPath = resolve(TEST_DIR, `${sid}_o.txt`);
+      writeFileSync(promptPath, `Prompt for ${marker}.`, "utf8");
+      return { sid, promptPath, outputPath, marker };
+    };
+
+    const sessions = [mkSession("AAA"), mkSession("BBB")];
+
+    // Start both sessions back-to-back so their turns overlap on the broker
+    for (const s of sessions) {
+      const r = cli(
+        ["start", s.promptPath, s.outputPath, "--session", s.sid, "--review-dir", TEST_DIR],
+        {
+          broker: true,
+          home: BROKER_HOME,
+          tagThread: true,
+          turnDelay: 500,
+          turnText: `Turn output for ${s.marker}.\n\n[VERDICT] - APPROVE`,
+        }
+      );
+      assert.equal(r.exit, 0, `start failed for ${s.marker}: ${r.stderr}`);
+    }
+
+    // Wait for both to complete
+    for (const s of sessions) {
+      const progress = await pollToComplete(s.sid);
+      assert.equal(progress.status, "completed", `session ${s.marker} status`);
+      assert.ok(existsSync(s.outputPath), `output missing for ${s.marker}`);
+    }
+
+    // Each output should contain exactly one threadId tag, and the two
+    // sessions must have different tags.
+    const tag1 = readFileSync(sessions[0].outputPath, "utf8").match(/\[fake-thread-\d+\]/g) || [];
+    const tag2 = readFileSync(sessions[1].outputPath, "utf8").match(/\[fake-thread-\d+\]/g) || [];
+    assert.equal(tag1.length, 1, `session AAA has ${tag1.length} thread tags: ${tag1}`);
+    assert.equal(tag2.length, 1, `session BBB has ${tag2.length} thread tags: ${tag2}`);
+    assert.notEqual(tag1[0], tag2[0], "concurrent sessions leaked into each other");
+  });
+
+  it("serializes three concurrent turn-starts in FIFO order", async () => {
+    // Three simultaneous starts must each end up with exactly one unique
+    // threadId tag, proving the broker isolated each turn's notification
+    // stream from the others.
+    const sessions = Array.from({ length: 3 }, (_, i) => {
+      const sid = newSid();
+      const promptPath = resolve(TEST_DIR, `${sid}_p.txt`);
+      const outputPath = resolve(TEST_DIR, `${sid}_o.txt`);
+      writeFileSync(promptPath, `Prompt ${i}.`, "utf8");
+      return { sid, promptPath, outputPath, idx: i };
+    });
+
+    for (const s of sessions) {
+      const r = cli(
+        ["start", s.promptPath, s.outputPath, "--session", s.sid, "--review-dir", TEST_DIR],
+        {
+          broker: true,
+          home: BROKER_HOME,
+          tagThread: true,
+          turnDelay: 400,
+          turnText: `Content ${s.idx}.\n\n[VERDICT] - APPROVE`,
+        }
+      );
+      assert.equal(r.exit, 0, `start ${s.idx} failed: ${r.stderr}`);
+    }
+
+    for (const s of sessions) {
+      const progress = await pollToComplete(s.sid, 45_000);
+      assert.equal(progress.status, "completed", `session ${s.idx} status`);
+    }
+
+    const tags = sessions.map((s) => {
+      const content = readFileSync(s.outputPath, "utf8");
+      const match = content.match(/\[fake-thread-\d+\]/g) || [];
+      assert.equal(match.length, 1, `session ${s.idx} has ${match.length} thread tags: ${match}`);
+      return match[0];
+    });
+
+    // All three tags must be distinct — no session received another's deltas.
+    const unique = new Set(tags);
+    assert.equal(unique.size, tags.length, `concurrent sessions leaked: ${tags}`);
   });
 });
 

--- a/plugins/codex-review-core/test/fake-codex.mjs
+++ b/plugins/codex-review-core/test/fake-codex.mjs
@@ -7,10 +7,13 @@
  * Responds to: initialize, account/read, thread/start, thread/resume, turn/start.
  *
  * Environment variables:
- *   FAKE_TURN_DELAY_MS   — Delay before completing the turn (default: 200)
- *   FAKE_TURN_TEXT        — Response text for the turn (default: "Fake review output")
- *   FAKE_TURN_FAIL        — If set, turn fails with this message
- *   FAKE_AUTH_FAIL         — If set, account/read returns no account
+ *   FAKE_TURN_DELAY_MS     — Delay before emitting the first delta (default: 200)
+ *   FAKE_TURN_TEXT          — Response text for the turn
+ *   FAKE_TURN_FAIL          — If set, turn fails with this message
+ *   FAKE_AUTH_FAIL          — If set, account/read returns no account
+ *   FAKE_TAG_THREAD         — If set, prefix each delta with `[<threadId>] `
+ *                              so concurrent-turn tests can distinguish streams.
+ *   FAKE_DELTA_INTERVAL_MS  — Delay between delta chunks (default: 20)
  */
 
 import { createInterface } from "node:readline";
@@ -19,6 +22,8 @@ const TURN_DELAY = parseInt(process.env.FAKE_TURN_DELAY_MS || "200", 10);
 const TURN_TEXT = process.env.FAKE_TURN_TEXT || "Fake review output for testing.\n\n[VERDICT] - APPROVE";
 const TURN_FAIL = process.env.FAKE_TURN_FAIL || "";
 const AUTH_FAIL = !!process.env.FAKE_AUTH_FAIL;
+const TAG_THREAD = !!process.env.FAKE_TAG_THREAD;
+const DELTA_INTERVAL_MS = parseInt(process.env.FAKE_DELTA_INTERVAL_MS || "20", 10);
 
 const rl = createInterface({ input: process.stdin });
 
@@ -69,14 +74,17 @@ function handleRequest(msg) {
           return;
         }
 
-        // Send deltas in chunks
-        const chunks = TURN_TEXT.match(/.{1,50}/g) || [TURN_TEXT];
+        // Optionally tag each delta with its threadId so concurrent-turn
+        // tests can detect if deltas from one thread leak into another.
+        const tagged = TAG_THREAD ? `[${threadId}] ${TURN_TEXT}` : TURN_TEXT;
+        const chunks = tagged.match(/.{1,50}/g) || [tagged];
+
         let delay = 0;
         for (const chunk of chunks) {
           setTimeout(() => {
             send({ method: "item/agentMessage/delta", params: { delta: chunk } });
           }, delay);
-          delay += 20;
+          delay += DELTA_INTERVAL_MS;
         }
 
         // Send completion after all deltas


### PR DESCRIPTION
## Summary

- **Bug**: broker forwarded every upstream notification to every subscriber matching by method name, so two concurrent `turn/start` requests produced interleaved `item/agentMessage/delta` streams. Reviews sharing a broker would swap or merge outputs (observed as 30 s turns returning short, off-topic text from another project's review).
- **Fix**: serialize turn ownership in `broker.mjs` — one `turn/start` at a time holds the notification stream, the rest queue FIFO. Turn-scoped notifications (`item/*`, `turn/*`, `error`) route only to the active turn's socket; stale notifications drop.
- **Side fix**: add `windowsHide: true` to every `spawn()` so the Windows cmd flash goes away (`codex app-server`, broker, and workers).

## Root cause (in code)

`broker.mjs` `_handleMessage` — forwards every notification to every subscriber whose `methods` list matches by name, with no threadId / turn scoping. `BrokerClient.startTurn` in `codex-review.mjs` appends every delta into `agentText` with no threadId filter. Two workers → two subscribers to `item/agentMessage/delta` → each receives both streams → output is a scrambled union.

## What changes in broker.mjs

- `AppServerConnection.acquireTurn(socket, timeoutMs)` — awaitable mutex granting exclusive ownership of the upstream notification stream. Safety timer (client timeout + 15 s) force-releases if upstream stalls.
- `_handleMessage` splits routing:
  - `item/*`, `turn/*`, `error` → active turn's socket only (drop if none)
  - Other notifications → existing `subscribe` fan-out
- `turn/completed` / `turn/failed` / `turn/cancelled`, socket close, and safety timeout all release the mutex and grant the next waiter.
- `_onConnection` wraps `turn/start` requests with `acquireTurn` and releases on upstream request failure.

## Tests

`test/codex-review.test.mjs` adds a `broker turn serialization` suite:

- **does not mix deltas between concurrent turns** — 2 sessions started back-to-back through a shared broker; each output contains exactly one `[fake-thread-N]` tag and the two tags are distinct.
- **serializes three concurrent turn-starts in FIFO order** — 3 sessions; all three outputs must get distinct thread tags.

`fake-codex.mjs` gains `FAKE_TAG_THREAD=1` so deltas can be tagged with their threadId for leak detection.

All 14 tests pass locally (`node --test test/codex-review.test.mjs`).

## Test plan

- [x] `node --test test/codex-review.test.mjs` — 14/14 pass
- [x] Broker binary + `codex-review.mjs` synced to `~/.claude/bin/` and plugin cache (`1.2.0/bin`) for immediate effect; next Codex session on this machine uses the fixed broker.
- [ ] Verify on another Windows machine that no cmd window appears when starting a review.
- [ ] After merge: tag `v1.2.1` and publish GH release so `claude plugin install` picks it up for other users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)