### PR TITLE
chore: bump versions to 2.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "sanghyun-io's Claude Code plugins",
-    "version": "2.0.0"
+    "version": "2.1.0"
   },
   "plugins": [
     {
       "name": "codex-core",
       "source": "./plugins/codex-core",
       "description": "Codex integration for Claude Code — natural language router, A+ delegation, session ops, and the codex-review CLI runtime",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "author": { "name": "sanghyun-io" },
       "homepage": "https://github.com/sanghyun-io/codex-app-server-plugin",
       "license": "MIT",
@@ -23,7 +23,7 @@
       "name": "codex-code-review",
       "source": "./plugins/codex-code-review",
       "description": "Iterative and adversarial code review workflows powered by Codex (requires codex-core)",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "author": { "name": "sanghyun-io" },
       "homepage": "https://github.com/sanghyun-io/codex-app-server-plugin",
       "license": "MIT",

--- a/plugins/codex-code-review/.claude-plugin/plugin.json
+++ b/plugins/codex-code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-code-review",
   "description": "Iterative and adversarial code review workflows powered by Codex (requires codex-core)",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "sanghyun-io",
     "email": "ppkimsanh@gmail.com"

--- a/plugins/codex-core/.claude-plugin/plugin.json
+++ b/plugins/codex-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-core",
   "description": "Codex integration for Claude Code — natural language router, A+ delegation, session ops, and the codex-review CLI runtime",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "sanghyun-io",
     "email": "ppkimsanh@gmail.com"


### PR DESCRIPTION
v2.0.0 git tag conflicted with the prior "monorepo split" release. Bumping to v2.1.0 instead.

- codex-core: 2.0.0 → 2.1.0
- codex-code-review: 2.0.0 → 2.1.0
- marketplace metadata: 2.0.0 → 2.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)