### PR TITLE
feat(core): bump default Codex model to gpt-5.5 (v2.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "sanghyun-io's Claude Code plugins",
-    "version": "2.1.0"
+    "version": "2.2.0"
   },
   "plugins": [
     {
       "name": "codex-core",
       "source": "./plugins/codex-core",
       "description": "Codex integration for Claude Code — natural language router, A+ delegation, session ops, and the codex-review CLI runtime",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "author": { "name": "sanghyun-io" },
       "homepage": "https://github.com/sanghyun-io/codex-app-server-plugin",
       "license": "MIT",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # codex-app-server-plugin
 
-A Claude Code plugin marketplace that integrates the **Codex App Server** with Claude Code. Lets you call Codex (gpt-5.4 by default, configurable) from natural language or slash commands, with stateful threads and cross-turn context reuse.
+A Claude Code plugin marketplace that integrates the **Codex App Server** with Claude Code. Lets you call Codex (gpt-5.5 by default, configurable) from natural language or slash commands, with stateful threads and cross-turn context reuse.
 
 ## Plugins
 
@@ -20,7 +20,7 @@ Claude Code
   └─ codex-review.mjs              (JSON-RPC wrapper — installed by codex-core)
        └─ broker.mjs (TCP, opt-out) (persistent IPC serializer — auth cached, warm app-server)
             └─ codex app-server      (single subprocess, shared across workers)
-                 └─ gpt-5.4            (stateful thread, model is configurable)
+                 └─ gpt-5.5            (stateful thread, model is configurable)
 ```
 
 The wrapper manages thread lifecycle via three commands:
@@ -30,7 +30,7 @@ The wrapper manages thread lifecycle via three commands:
 
 By default, workers connect through a **persistent broker** (`broker.mjs`) that holds a single warm `codex app-server` subprocess on a localhost TCP port. This eliminates per-turn spawn overhead (~2–3s) and reuses a single auth check across all workers. The broker auto-starts on first use, idles out after 10 minutes, and is torn down by the `SessionEnd` hook. Set `CODEX_REVIEW_NO_BROKER=1` to bypass the broker and spawn `codex app-server` directly (used in tests).
 
-The model used for each call is configurable (priority: CLI flag > env var > default `gpt-5.4`):
+The model used for each call is configurable (priority: CLI flag > env var > default `gpt-5.5`):
 
 ```bash
 # CLI flag
@@ -44,7 +44,7 @@ CODEX_REVIEW_MODEL=gpt-4o node codex-review.mjs start ...
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `CODEX_REVIEW_MODEL` | Override default model | `gpt-5.4` |
+| `CODEX_REVIEW_MODEL` | Override default model | `gpt-5.5` |
 | `CODEX_REVIEW_NO_BROKER` | Skip broker, spawn `codex app-server` directly (set to `1`) | unset |
 | `CODEX_BINARY` | Path to a custom binary used in place of `codex app-server` (testing hook) | unset |
 
@@ -133,7 +133,7 @@ Every Codex-backed skill accepts `--model <name>`. Priority:
 
 1. `--model <name>` CLI flag (highest)
 2. `CODEX_REVIEW_MODEL` environment variable
-3. Default (`gpt-5.4`)
+3. Default (`gpt-5.5`)
 
 Recognized prefixes for natural language extraction: `gpt-*`, `o1*`, `o3*`, `o4*`, `claude-*`, `gemini-*`. Selected model is stored in the thread's `state.json` and reused automatically across follow-up turns.
 

--- a/plugins/codex-code-review/rules/codex-code-review.md
+++ b/plugins/codex-code-review/rules/codex-code-review.md
@@ -43,7 +43,7 @@ triggers:
 | (없음) | 현재 브랜치 vs default branch (`git diff $DEFAULT_BRANCH...HEAD`) |
 | `PR#N` | `gh pr diff N` |
 | `--base <ref>` | `git diff <ref>...HEAD` |
-| `--model <name>` | Codex 모델 오버라이드 (default: `gpt-5.4`, env: `CODEX_REVIEW_MODEL`) |
+| `--model <name>` | Codex 모델 오버라이드 (default: `gpt-5.5`, env: `CODEX_REVIEW_MODEL`) |
 | `--with-opus` | Opus 교차검증 활성화 |
 
 ### Base Commit 기록
@@ -66,7 +66,7 @@ CURRENT_COMMIT=$(git rev-parse HEAD)
 | 상황 | 처리 |
 |------|------|
 | `--model <X>` 명시 | 모든 `codex-review start` 호출에 `--model "<X>"` 인자 추가 |
-| 미명시 | 인자 생략 (CLI가 `CODEX_REVIEW_MODEL` 환경변수 또는 기본값 `gpt-5.4` 사용) |
+| 미명시 | 인자 생략 (CLI가 `CODEX_REVIEW_MODEL` 환경변수 또는 기본값 `gpt-5.5` 사용) |
 
 ### CLI 명령 형식
 
@@ -88,7 +88,7 @@ node "{HOME_LITERAL}/.claude/bin/codex-review.mjs" start \
 ### 최종 리포트에 모델 표시
 
 `codex-review status` 또는 `cr_{SID}_state.json`에서 실제 사용된 모델을 추출하여 최종 리포트의
-"심사 모델" / "최종 Verdict" 섹션의 `Codex (gpt-5.4)` 표기를 실제 모델명으로 교체한다.
+"심사 모델" / "최종 Verdict" 섹션의 `Codex (gpt-5.5)` 표기를 실제 모델명으로 교체한다.
 
 ---
 
@@ -238,7 +238,7 @@ Opus 교차검증 실패 시 Codex 결과만으로 진행 (리포트에 "Opus �
 - **라운드 수**: {total_rounds}
 
 ## 심사 모델
-- Codex (gpt-5.4): {라운드별 verdict 요약}
+- Codex (gpt-5.5): {라운드별 verdict 요약}
 - Opus 교차검증: ✅ / ⏭️ SKIP (사유)
 
 ---
@@ -269,7 +269,7 @@ Opus 교차검증 실패 시 Codex 결과만으로 진행 (리포트에 "Opus �
 
 | 모델 | 최종 라운드 |
 |---|---|
-| Codex (gpt-5.4) | APPROVE / REVISE / REJECT |
+| Codex (gpt-5.5) | APPROVE / REVISE / REJECT |
 | Opus (선택) | APPROVE / REVISE / REJECT |
 | **종합** | **APPROVE / REVISE / REJECT** |
 ```

--- a/plugins/codex-code-review/rules/codex-red-review.md
+++ b/plugins/codex-code-review/rules/codex-red-review.md
@@ -201,7 +201,7 @@ code-review의 최종 리포트 형식을 기반으로 하되, verdict 줄을 �
 ```
 | 모델 | 최종 라운드 |
 |---|---|
-| Codex (gpt-5.4) | SECURE / AT_RISK / COMPROMISED |
+| Codex (gpt-5.5) | SECURE / AT_RISK / COMPROMISED |
 | Opus (선택) | SECURE / AT_RISK / COMPROMISED |
 | **종합** | **SECURE / AT_RISK / COMPROMISED** |
 ```

--- a/plugins/codex-code-review/skills/code-review/SKILL.md
+++ b/plugins/codex-code-review/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Start a multi-round iterative code review using Codex App Server (default model gpt-5.4). Tracks issues across rounds until convergence. Reviews current branch vs default branch by default.
+description: Start a multi-round iterative code review using Codex App Server (default model gpt-5.5). Tracks issues across rounds until convergence. Reviews current branch vs default branch by default.
 argument-hint: "[PR#N | --base <ref>] [--model <name>] [--with-opus]"
 invocation:
   command: code-review
@@ -16,7 +16,7 @@ Start a multi-round code review session following the protocol in `~/.claude/rul
 - `(no args)` — Review current branch vs default branch
 - `PR#N` — Review PR number N via `gh pr diff N`
 - `--base <ref>` — Review against a specific base ref
-- `--model <name>` — Override Codex model (default: `gpt-5.4`, env: `CODEX_REVIEW_MODEL`)
+- `--model <name>` — Override Codex model (default: `gpt-5.5`, env: `CODEX_REVIEW_MODEL`)
 - `--with-opus` — Enable Opus cross-validation after Codex review
 
 ## Examples
@@ -25,7 +25,7 @@ Start a multi-round code review session following the protocol in `~/.claude/rul
 /codex-code-review:code-review
 /codex-code-review:code-review PR#123
 /codex-code-review:code-review --base develop --model gpt-4o
-/codex-code-review:code-review --with-opus --model gpt-5.4
+/codex-code-review:code-review --with-opus
 ```
 
 ## Execution

--- a/plugins/codex-code-review/skills/red-review/SKILL.md
+++ b/plugins/codex-code-review/skills/red-review/SKILL.md
@@ -18,7 +18,7 @@ Follow the complete workflow defined in `~/.claude/rules/codex-red-review.md`.
 - `(no args)` — Review current branch vs default branch
 - `PR#N` — Review PR number N via `gh pr diff N`
 - `--base <ref>` — Review against a specific base ref
-- `--model <name>` — Override Codex model (default: `gpt-5.4`, env: `CODEX_REVIEW_MODEL`)
+- `--model <name>` — Override Codex model (default: `gpt-5.5`, env: `CODEX_REVIEW_MODEL`)
 - `--with-opus` — Enable Opus cross-validation after Codex review
 
 ## Examples

--- a/plugins/codex-core/bin/codex-review.mjs
+++ b/plugins/codex-core/bin/codex-review.mjs
@@ -11,7 +11,7 @@
  *   close      --session <SID> --review-dir <DIR>                     Clean up all session files
  *
  * Options:
- *   --model <MODEL>       Model override (default: gpt-5.4, env: CODEX_REVIEW_MODEL)
+ *   --model <MODEL>       Model override (default: gpt-5.5, env: CODEX_REVIEW_MODEL)
  *   --timeout <MS>        Hard timeout in ms (default: 1800000, env: CODEX_REVIEW_TIMEOUT)
  *   --foreground          Run synchronously (v1 compat, no background worker)
  *   --stdin               Read prompt from stdin and write to <prompt-file> (avoids Write tool permission)
@@ -43,7 +43,7 @@ import { randomBytes } from "node:crypto";
 // Config
 // ---------------------------------------------------------------------------
 
-const DEFAULT_MODEL = "gpt-5.4";
+const DEFAULT_MODEL = "gpt-5.5";
 const DEFAULT_HARD_TIMEOUT_MS = 1_800_000; // 30 min safety net
 const INIT_TIMEOUT_MS = 30_000;            // 30s for init/auth requests
 const PROGRESS_INTERVAL_MS = 3_000;        // 3s between progress file writes
@@ -1271,7 +1271,7 @@ Usage:
   codex-review scope      [<base-ref>]
 
 Options:
-  --model <MODEL>       Model to use (default: gpt-5.4, env: CODEX_REVIEW_MODEL)
+  --model <MODEL>       Model to use (default: gpt-5.5, env: CODEX_REVIEW_MODEL)
   --timeout <MS>        Hard timeout in ms (default: 1800000, env: CODEX_REVIEW_TIMEOUT)
   --foreground          Run synchronously (v1 compat)
   --stdin               Read prompt from stdin, write to <prompt-file>

--- a/plugins/codex-core/rules/codex-delegate.md
+++ b/plugins/codex-core/rules/codex-delegate.md
@@ -75,7 +75,7 @@ Codex에게 자율적 작업을 위임하되, 실제 파일 변경은 Claude가 
 | 상황 | 처리 |
 |------|------|
 | `--model <X>` 명시 | Turn 1 `codex-review start` 호출에 `--model "<X>"` 인자 추가 |
-| 미명시 | 인자 생략 (CLI가 `CODEX_REVIEW_MODEL` 환경변수 또는 기본값 `gpt-5.4` 사용) |
+| 미명시 | 인자 생략 (CLI가 `CODEX_REVIEW_MODEL` 환경변수 또는 기본값 `gpt-5.5` 사용) |
 
 > **follow-up 자동 처리**: `start`에서 지정한 모델은 `dg_{SID}_state.json`에 저장되어
 > 후속 `follow-up` 호출에서 자동 재사용된다. follow-up에 `--model`을 다시 명시할 필요는 없다.

--- a/plugins/codex-core/rules/codex-delegation.md
+++ b/plugins/codex-core/rules/codex-delegation.md
@@ -167,7 +167,7 @@ Claude: codex-review close로 Thread 종료
 
 다음 prefix 중 하나로 시작하는 토큰을 모델명 후보로 간주한다:
 
-- `gpt-*` (예: `gpt-4o`, `gpt-5.4`, `gpt-5`)
+- `gpt-*` (예: `gpt-4o`, `gpt-5.5`, `gpt-5`)
 - `o1*`, `o3*`, `o4*` (예: `o1`, `o1-mini`, `o3-pro`)
 - `claude-*` (예: `claude-3.5-sonnet`)
 - `gemini-*`

--- a/plugins/codex-core/rules/codex-session-ops.md
+++ b/plugins/codex-core/rules/codex-session-ops.md
@@ -75,7 +75,7 @@ code-review, delegate, red-review 등 모든 스킬이 사용하는 세션 파�
 ```json
 {
   "threadId": "thr_abc123...",
-  "model": "gpt-5.4",
+  "model": "gpt-5.5",
   "turnCount": 3,
   "lastTurnAt": "2026-04-10T10:25:12.456Z"
 }
@@ -100,15 +100,15 @@ code-review, delegate, red-review 등 모든 스킬이 사용하는 세션 파�
 
 | Session | Skill | Model | Elapsed | Chars | Status |
 |---------|-------|-------|--------:|------:|--------|
-| cr_123456_78 | code-review | gpt-5.4 | 45s | 3,200 | running |
-| dg_123457_89 | delegate | gpt-5.4 | 2m 12s | 8,500 | running ⚠️ |
+| cr_123456_78 | code-review | gpt-5.5 | 45s | 3,200 | running |
+| dg_123457_89 | delegate | gpt-5.5 | 2m 12s | 8,500 | running ⚠️ |
 
 ## Completed Sessions (N)
 
 | Session | Skill | Model | Turns | Last Updated | Status |
 |---------|-------|-------|:-----:|--------------|--------|
-| cr_123400_12 | code-review | gpt-5.4 | 3 | 2026-04-10 09:45 | completed |
-| dg_123410_34 | delegate | gpt-5.4 | 5 | 2026-04-10 10:15 | cancelled |
+| cr_123400_12 | code-review | gpt-5.5 | 3 | 2026-04-10 09:45 | completed |
+| dg_123410_34 | delegate | gpt-5.5 | 5 | 2026-04-10 10:15 | cancelled |
 ```
 
 > **⚠️ 강조**: 2분 이상 실행 중인 세션.

--- a/plugins/codex-core/rules/review-protocol.md
+++ b/plugins/codex-core/rules/review-protocol.md
@@ -7,7 +7,7 @@ Codex를 이용한 리뷰 실행 시 아래 프로토콜을 반드시 따를 것
 
 | 모델 | Provider | 호출 방식 |
 |------|----------|-----------|
-| gpt-5.4 (기본) | OpenAI (App Server) | `codex-review` CLI wrapper (`~/.claude/bin/codex-review.mjs`) |
+| gpt-5.5 (기본) | OpenAI (App Server) | `codex-review` CLI wrapper (`~/.claude/bin/codex-review.mjs`) |
 
 #### 호출 방식
 
@@ -18,7 +18,7 @@ Codex를 이용한 리뷰 실행 시 아래 프로토콜을 반드시 따를 것
 | Thread 모델 | Stateful — Thread 내에서 follow-up Turn으로 반복 리뷰 가능 |
 | 인증 | ChatGPT 관리형 OAuth (`codex login`으로 사전 인증 필요) |
 | Fallback | 없음 — 실패 시 즉시 PASS |
-| 모델 오버라이드 | `--model <MODEL>` CLI 플래그 또는 `CODEX_REVIEW_MODEL` 환경변수 (기본값: `gpt-5.4`) |
+| 모델 오버라이드 | `--model <MODEL>` CLI 플래그 또는 `CODEX_REVIEW_MODEL` 환경변수 (기본값: `gpt-5.5`) |
 | 타임아웃 오버라이드 | `--timeout <MS>` CLI 플래그 또는 `CODEX_REVIEW_TIMEOUT` 환경변수 (기본값: `1800000` / 30분) |
 | 실행 모드 | **비동기** (백그라운드 워커) — `start`/`follow-up`은 즉시 반환, `status`로 폴링 |
 

--- a/plugins/codex-core/skills/delegate/SKILL.md
+++ b/plugins/codex-core/skills/delegate/SKILL.md
@@ -18,14 +18,14 @@ Follow the complete workflow defined in `~/.claude/rules/codex-delegate.md`.
 ## Arguments
 
 - `<task description>` — Free-form task description (e.g., "Fix the null pointer in UserService.login")
-- `--model <name>` — Override Codex model (default: `gpt-5.4`)
+- `--model <name>` — Override Codex model (default: `gpt-5.5`)
 - `--read-only` — Question-answer mode: Codex answers without proposing file changes
 
 ## Examples
 
 ```
 /codex-core:delegate Refactor auth middleware to use JWT instead of session tokens
-/codex-core:delegate Find and fix the race condition in OrderService --model gpt-5.4
+/codex-core:delegate Find and fix the race condition in OrderService --model gpt-4o
 /codex-core:delegate Why does /api/v1/users return 500 when email is null --read-only
 ```
 

--- a/plugins/codex-core/skills/setup/SKILL.md
+++ b/plugins/codex-core/skills/setup/SKILL.md
@@ -384,7 +384,7 @@ Show the final summary:
   "Codex에게 이 버그 고쳐달라고 해" / "Codex로 gpt-4o 써서 검토 부탁"
   같은 자연어도 codex-delegation 라우터가 감지해서 적절한 스킬로 연결됩니다.
 
-모델: gpt-5.4 (Stateful Thread, --model 플래그 / CODEX_REVIEW_MODEL 환경변수로 오버라이드)
+모델: gpt-5.5 (Stateful Thread, --model 플래그 / CODEX_REVIEW_MODEL 환경변수로 오버라이드)
 브로커: 기본 활성화 (CODEX_REVIEW_NO_BROKER=1 로 비활성화 가능)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```


### PR DESCRIPTION
## Summary

- Updates \`DEFAULT_MODEL\` in \`codex-review.mjs\` from \`gpt-5.4\` to \`gpt-5.5\`
- Refreshes every documentation/rule/SKILL reference to match
- Override examples switched to \`gpt-4o\` so they actually demonstrate overriding (rather than re-stating the new default)

## Why

\`gpt-5.5\` is the new recommended default for new Codex threads. The previous default (\`gpt-5.4\`) is still callable via \`--model gpt-5.4\` if needed.

## Backward Compatibility

| Scenario | Impact |
|----------|--------|
| Users with \`--model\` flag | ✅ unaffected (override priority unchanged) |
| Users with \`CODEX_REVIEW_MODEL\` env var | ✅ unaffected (env > default) |
| Existing in-flight threads | ✅ unaffected (model locked in \`state.json\` at thread start) |
| New threads after upgrade | Now use \`gpt-5.5\` |

## What Changed

| File | Change |
|------|--------|
| \`bin/codex-review.mjs:46\` | \`DEFAULT_MODEL\` constant + 2 comment refs |
| \`README.md\` | header, diagram, env table, override section, default mentions |
| \`rules/review-protocol.md\` | provider table + override row |
| \`rules/codex-delegation.md\` | model prefix example list |
| \`rules/codex-delegate.md\` | default value mention |
| \`rules/codex-session-ops.md\` | example progress.json/state.json content |
| \`rules/codex-code-review.md\` | default mentions, verdict table, final report template |
| \`rules/codex-red-review.md\` | verdict table |
| \`skills/{delegate,setup,code-review,red-review}/SKILL.md\` | default labels in Arguments + Examples |

## User Migration

Existing v2.1.0 users get the new default by running:

\`\`\`
/plugin marketplace update sanghyun-io
/plugin update codex-core@sanghyun-io
/codex-core:setup
\`\`\`

The third command is **required** — \`/plugin update\` only refreshes the cache, while \`/codex-core:setup\` actually copies the new \`codex-review.mjs\` to \`~/.claude/bin/\` (the binary that gets executed).

## Versions

- codex-core: 2.1.0 → **2.2.0** (minor — default value change)
- codex-code-review: 2.1.0 (unchanged — only docs touched)
- marketplace metadata: 2.1.0 → 2.2.0

## Test Plan

- [ ] After \`/codex-core:setup\`, verify \`~/.claude/bin/codex-review.mjs\` contains \`DEFAULT_MODEL = "gpt-5.5"\`
- [ ] New \`/codex-core:delegate\` session uses gpt-5.5 (check \`state.json\` after first turn)
- [ ] \`--model gpt-4o\` still overrides correctly
- [ ] \`CODEX_REVIEW_MODEL=gpt-4o\` still overrides correctly
- [ ] Existing thread resume works (no model swap mid-thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)