### PR TITLE
docs(skills): 스킬 결과를 유저에게 쉬운 말로 전달하도록 안내 추가

### DIFF
--- a/plugins/codex-code-review/skills/code-review/SKILL.md
+++ b/plugins/codex-code-review/skills/code-review/SKILL.md
@@ -36,3 +36,14 @@ Follow the complete workflow defined in `~/.claude/rules/codex-code-review.md`.
 
 If the rules file is not yet active, ensure it is imported in `~/.claude/CLAUDE.md`.
 Run `/codex-core:setup` if you haven't configured the plugin yet.
+
+## Reporting to the User (Plain Language)
+
+When you relay review results back to the user, use plain, easy words — not hard technical terms. Do NOT use metaphors or analogies; just say the same thing in simpler words. And do NOT compress everything into one short line — explain enough that someone non-technical understands without asking follow-ups.
+
+- Replace hard terms with everyday words. If a technical term is unavoidable, write it and then add a short plain-words explanation right after it (e.g. "race condition(두 작업이 동시에 실행돼서 순서가 꼬이는 문제)").
+- Do NOT surface mechanism words like Thread, Turn, threadId, exit code, polling, JSON-RPC, App Server, or `rr_`/`cr_` session prefixes in the user-facing summary at all.
+- For each issue, take a few sentences — not one terse line — to explain: what is wrong, why it actually matters, and what to do about it. Give enough context that the user does not have to ask "그래서 무슨 뜻이야?".
+- Explain severity in plain words about what happens if ignored ("이건 지금 안 고치면 실제로 문제가 생김" vs "당장은 괜찮고 나중에 정리해도 됨"), not just the HIGH/MED/LOW label.
+- Keep the deep technical detail available, but only show it when the user asks ("자세히 보여줘").
+- Always write the final report to the user in Korean.

--- a/plugins/codex-code-review/skills/red-review/SKILL.md
+++ b/plugins/codex-code-review/skills/red-review/SKILL.md
@@ -36,3 +36,14 @@ $ARGUMENTS
 
 If the rules file is not yet active, ensure it is imported in `~/.claude/CLAUDE.md`.
 Run `/codex-core:setup` if you haven't configured the plugin yet.
+
+## Reporting to the User (Plain Language)
+
+When you relay the security findings back to the user, use plain, easy words — not hard technical terms. Do NOT use metaphors or analogies; just say the same thing in simpler words. And do NOT compress everything into one short line — explain enough that someone non-technical understands without asking follow-ups.
+
+- Replace hard terms with everyday words. If a security term is unavoidable, write it and then add a short plain-words explanation right after it (e.g. "SQL injection(공격자가 입력칸에 명령어를 넣어 데이터베이스를 조작하는 공격)").
+- Do NOT surface mechanism words like Thread, Turn, threadId, exit code, polling, JSON-RPC, App Server, or `rr_`/`cr_` session prefixes in the user-facing summary at all.
+- For each finding, take a few sentences — not one terse line — to explain: how an attacker could actually exploit it, what they would gain, and what to do to close the hole. Give enough context that the user understands the danger without asking. Keep CVE/CWE names only as an optional aside.
+- Explain severity in plain words about the real danger ("이건 뚫리면 실제로 데이터가 새거나 계정이 털릴 수 있음" vs "이론상 가능하지만 실제로 악용되긴 어려움"), not just the HIGH/MED/LOW label.
+- Keep the deep technical detail available, but only show it when the user asks ("자세히 보여줘").
+- Always write the final report to the user in Korean.

--- a/plugins/codex-core/skills/delegate/SKILL.md
+++ b/plugins/codex-core/skills/delegate/SKILL.md
@@ -35,3 +35,15 @@ $ARGUMENTS
 
 If the rules file is not yet active, ensure it is imported in `~/.claude/CLAUDE.md`.
 Run `/codex-core:setup` if you haven't configured the plugin yet.
+
+## Reporting to the User (Plain Language)
+
+When you report progress or the final result back to the user, use plain, easy words — not hard technical terms. Do NOT use metaphors or analogies; just say the same thing in simpler words. And do NOT compress everything into one short line — explain enough that someone non-technical understands what happened.
+
+- Replace hard terms with everyday words. If a technical term is unavoidable, write it and then add a short plain-words explanation right after it.
+- Do NOT surface mechanism words like Thread, Turn, threadId, exit code, polling, JSON-RPC, App Server, A+ pattern, or `dg_` session prefixes in the user-facing summary at all.
+- Describe each change in a few plain sentences: what was changed, how it was changed, and what the result was — enough that the user can follow along without reading code.
+- If verification (tests/build) ran, say in plain words whether it passed and what that means.
+- If something is blocked or failed, say it plainly and clearly state what you need from the user — do not bury it under status codes or jargon.
+- Keep the raw diff / deep technical detail available, but only show it when the user asks ("diff 보여줘", "자세히").
+- Always write the report to the user in Korean.

--- a/plugins/codex-core/skills/halt/SKILL.md
+++ b/plugins/codex-core/skills/halt/SKILL.md
@@ -25,3 +25,12 @@ $ARGUMENTS
 
 If the rules file is not yet active, ensure it is imported in `~/.claude/CLAUDE.md`.
 Run `/codex-core:setup` if you haven't configured the plugin yet.
+
+## Reporting to the User (Plain Language)
+
+When you confirm the cancellation back to the user, use plain, easy words — not hard technical terms. Do NOT use metaphors or analogies; just say the same thing in simpler words.
+
+- Say plainly what was stopped and whether any partial result was kept, in a sentence or two ("진행하던 작업을 멈췄어요. 중간까지 나온 내용은 지우지 않고 남겨뒀습니다").
+- Do NOT surface mechanism words like Thread, threadId, exit code, polling, JSON-RPC, App Server, or state-file names in the user-facing summary at all.
+- If a partial result exists, tell the user in plain words that they can look at it later and which command to use — do not just paste file paths as the main message.
+- Always write the confirmation to the user in Korean.

--- a/plugins/codex-core/skills/readout/SKILL.md
+++ b/plugins/codex-core/skills/readout/SKILL.md
@@ -24,3 +24,12 @@ $ARGUMENTS
 
 If the rules file is not yet active, ensure it is imported in `~/.claude/CLAUDE.md`.
 Run `/codex-core:setup` if you haven't configured the plugin yet.
+
+## Reporting to the User (Plain Language)
+
+When you display the session result to the user, use plain, easy words — not hard technical terms. Do NOT use metaphors or analogies; just say the same thing in simpler words. And do NOT compress everything into one short line — explain enough that the user understands what this session did.
+
+- Start with a plain summary, in a few sentences, of what this session actually found or did, then show the full output.
+- Do NOT surface mechanism words like Thread, threadId, exit code, polling, JSON-RPC, or App Server as the main message. The internal thread ID may appear as an optional reference line, clearly labeled "내부 식별자 (참고용)", not as something the user must act on.
+- Explain the metadata in plain words: which kind of task it was, which model, how many back-and-forth rounds happened, and whether it finished normally or was stopped partway.
+- Always write the summary to the user in Korean.

--- a/plugins/codex-core/skills/sessions/SKILL.md
+++ b/plugins/codex-core/skills/sessions/SKILL.md
@@ -25,3 +25,12 @@ $ARGUMENTS
 
 If the rules file is not yet active, ensure it is imported in `~/.claude/CLAUDE.md`.
 Run `/codex-core:setup` if you haven't configured the plugin yet.
+
+## Reporting to the User (Plain Language)
+
+When you show the session list to the user, use plain, easy words — not hard technical terms. Do NOT use metaphors or analogies; just say the same thing in simpler words.
+
+- Translate raw status values into plain words: `running` → "진행 중", `completed` → "끝남", `cancelled` → "중단됨", `failed`/`crashed` → "실패함".
+- Keep the table for reference, but above it write a plain summary in a sentence or two: how many tasks are running now, how many finished, and whether any look stuck — so the user gets the picture without reading every column.
+- Do NOT surface mechanism words like Thread, threadId, exit code, polling, JSON-RPC, or App Server in the user-facing summary at all. Session IDs and prefixes (`cr_`/`dg_`/`rr_`) may stay in the table since the user needs them to act, but explain in plain words what each kind of task is ("cr_로 시작하는 건 코드 검토 작업이에요").
+- Always write the summary to the user in Korean.


### PR DESCRIPTION
## 배경

각 codex 스킬(SKILL.md)은 그동안 내부 rules 파일(`~/.claude/rules/...`)을 "따라가서 실행하라"고만 안내했습니다. 그런데 그 rules 파일들은 구현 수준의 기술 용어(Thread, exit code, polling, JSON-RPC, 세션 prefix 등)로 쓰여 있어서, 스킬 실행 결과를 유저에게 전달할 때 그 어려운 용어가 그대로 새어 나가고 설명도 너무 짧게 끊기는 문제가 있었습니다.

## 변경 내용

6개 스킬에 **"Reporting to the User (Plain Language)"** 섹션을 추가했습니다:

- `codex-code-review`: `code-review`, `red-review`
- `codex-core`: `delegate`, `sessions`, `halt`, `readout`

각 섹션의 핵심 지시:

- 어려운 기술 용어를 **쉬운 단어로** 바꾼다 (비유/은유가 아니라 그냥 더 쉬운 표현으로)
- 한 줄로 압축하지 말고 **몇 문장으로 충분히 풀어서** 설명한다
- Thread / exit code / polling / JSON-RPC / 세션 prefix 같은 내부 동작 용어는 유저용 요약에 **노출하지 않는다**
- 심각도/상태는 라벨(HIGH/MED/LOW, running/failed)이 아니라 **실제로 무슨 일이 일어나는지** 쉬운 말로 푼다
- 깊은 기술 세부는 숨겨두고 **유저가 "자세히"라고 요청할 때만** 보여준다
- 최종 유저 응답은 **항상 한국어로** 작성한다

스킬별로 성격에 맞게 문구를 조정했습니다(리뷰=문제/위험 설명, delegate=변경 내역, sessions=상태 요약, halt/readout=중단·결과 안내).

`setup` 스킬은 이미 출력이 친절해서 변경하지 않았습니다.

## 영향 범위

- 문서(SKILL.md)만 변경. 기존 동작 로직 변경 없음 (전부 섹션 추가, 삭제 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)