### PR TITLE
docs(rules): Codex 폴링 대기 시 질문 제거 + 주기적 진행 안내

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "sanghyun-io's Claude Code plugins",
-    "version": "2.2.0"
+    "version": "2.2.2"
   },
   "plugins": [
     {
       "name": "codex-core",
       "source": "./plugins/codex-core",
       "description": "Codex integration for Claude Code — natural language router, A+ delegation, session ops, and the codex-review CLI runtime",
-      "version": "2.2.0",
+      "version": "2.2.2",
       "author": { "name": "sanghyun-io" },
       "homepage": "https://github.com/sanghyun-io/codex-app-server-plugin",
       "license": "MIT",
@@ -23,7 +23,7 @@
       "name": "codex-code-review",
       "source": "./plugins/codex-code-review",
       "description": "Iterative and adversarial code review workflows powered by Codex (requires codex-core)",
-      "version": "2.1.0",
+      "version": "2.2.2",
       "author": { "name": "sanghyun-io" },
       "homepage": "https://github.com/sanghyun-io/codex-app-server-plugin",
       "license": "MIT",

--- a/README.ko.md
+++ b/README.ko.md
@@ -74,6 +74,12 @@ CODEX_REVIEW_MODEL=gpt-4o node codex-review.mjs start ...
 
 `codex-core` install hook은 `~/.claude/CLAUDE.md`에 마커 블록을 append하여 규칙을 자동 활성화합니다. 블록은 idempotent하므로 재실행해도 안전합니다.
 
+### 업데이트
+
+`/plugin`으로 플러그인을 업데이트하면 **플러그인 캐시**가 갱신됩니다. 단, Claude가 실제로 읽는 규칙 파일은 `~/.claude/rules/*.md`에 있고(스킬이 캐시가 아니라 이곳에서 `@import`합니다), install hook이 업데이트 시 이곳으로 복사하므로 대부분의 경우 새 규칙이 자동으로 적용됩니다.
+
+> 반드시 필요한 것은 아니지만, **업데이트 후 `/codex-core:setup`을 한 번 실행하면 안전합니다.** 캐시와 `~/.claude/rules/`를 비교(diff)하여 변경된 파일만 다시 복사하므로, hook이 실행되지 않았더라도 최신 규칙이 확실히 활성화됩니다.
+
 ## Plugin: codex-core
 
 런타임 + 범용 워크플로. CLI 바이너리, broker, hook 스크립트, 스키마, 자연어 라우터, A+ 위임, 세션 운영을 설치합니다.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ CODEX_REVIEW_MODEL=gpt-4o node codex-review.mjs start ...
 
 The `codex-core` install hook auto-activates rules by appending a marker block to `~/.claude/CLAUDE.md`. The block is idempotent (safe to re-run).
 
+### Updating
+
+When you update the plugin via `/plugin`, the **plugin cache** is refreshed, but the rule files Claude actually reads live at `~/.claude/rules/*.md` (the skills `@import` them from there, not from the cache). The install hook copies them across on update, so in most cases the new rules apply automatically.
+
+> Not strictly required, but **running `/codex-core:setup` once after an update is the safe move.** It diffs the cache against `~/.claude/rules/` and re-copies anything that changed — guaranteeing the latest rules are active even if the hook didn't fire.
+
 ## Plugin: codex-core
 
 The runtime + universal workflows. Installs CLI binary, broker, hook scripts, schemas, the natural language router, A+ delegation, and session operations.

--- a/plugins/codex-code-review/.claude-plugin/plugin.json
+++ b/plugins/codex-code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-code-review",
   "description": "Iterative and adversarial code review workflows powered by Codex (requires codex-core)",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "author": {
     "name": "sanghyun-io",
     "email": "ppkimsanh@gmail.com"

--- a/plugins/codex-code-review/rules/codex-code-review.md
+++ b/plugins/codex-code-review/rules/codex-code-review.md
@@ -119,11 +119,11 @@ review-protocol.md의 실행 규칙을 따른다. v2에서는 **비동기 실행
 
 1. `codex-review start` → 워커 spawn, 즉시 반환 (exit 0)
 2. `codex-review status` → 30초 간격 폴링 (exit 7=실행중, 0=완료)
-3. 2분 초과 시 AskUserQuestion으로 사용자 알림 (계속/취소/PASS)
+3. 묻지 않고 계속 대기, 2분마다 진행 안내 1줄 (30분 하드 타임아웃까지)
 
 파일 네이밍: `cr_{SID}_r1_prompt.txt`, `cr_{SID}_r1_output.txt`
 
-> 자세한 폴링/알림 절차는 review-protocol.md **PHASE 1 Step 3** 참조.
+> 자세한 폴링/진행 안내 절차는 review-protocol.md **PHASE 1 Step 2** 참조.
 
 ### Step 4: 결과 처리
 
@@ -284,7 +284,7 @@ review-protocol.md v2의 비동기 실행 규칙을 적용한다:
 - `codex-review` CLI wrapper (`codex-review.mjs` v2) 사용
 - **비동기 실행**: `start`/`follow-up` → `status` 폴링 → 결과 수집
 - Exit code 기반 에러 처리 (review-protocol.md 참조)
-- 2분 초과 시 사용자 알림 (계속/취소/PASS)
+- 묻지 않고 계속 대기, 2분마다 진행 안내 (중단은 사용자가 직접 `/codex-core:halt`)
 
 ### 파일 네이밍 (코드 리뷰 전용)
 

--- a/plugins/codex-code-review/rules/codex-red-review.md
+++ b/plugins/codex-code-review/rules/codex-red-review.md
@@ -77,7 +77,7 @@ node "{HOME_LITERAL}/.claude/bin/codex-review.mjs" start "{HOME_LITERAL}/.claude
 `$ARGUMENTS`에 `--model <X>`가 있으면 위 명령 끝에 `--model "<X>"`를 추가한다.
 모델 오버라이드 처리 규칙은 `codex-code-review.md`의 **모델 오버라이드 처리** 섹션을 동일하게 따른다 (start에서 지정한 모델은 `rr_{SID}_state.json`에 저장되어 follow-up에 자동 재사용됨).
 
-폴링 패턴은 code-review와 동일 (30초 간격, 2분 초과 시 AskUserQuestion).
+폴링 패턴은 code-review와 동일 (30초 간격, 묻지 않고 계속 대기, 2분마다 진행 안내, 30분 하드 타임아웃까지).
 
 ### Step 4: 결과 처리
 

--- a/plugins/codex-core/.claude-plugin/plugin.json
+++ b/plugins/codex-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-core",
   "description": "Codex integration for Claude Code — natural language router, A+ delegation, session ops, and the codex-review CLI runtime",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "author": {
     "name": "sanghyun-io",
     "email": "ppkimsanh@gmail.com"

--- a/plugins/codex-core/rules/codex-delegate.md
+++ b/plugins/codex-core/rules/codex-delegate.md
@@ -100,7 +100,7 @@ echo "EXIT_CODE: $?"
 
 ### Step 2: 폴링
 
-review-protocol.md의 **PHASE 1 Step 2**와 동일 (status → 30초 간격, 2분 초과 시 AskUserQuestion).
+review-protocol.md의 **PHASE 1 Step 2**와 동일 (status → 30초 간격, 묻지 않고 계속 대기, 2분마다 진행 안내, 30분 하드 타임아웃까지).
 
 ### Step 3: 결과 수집 및 해석
 
@@ -311,7 +311,7 @@ review-protocol.md의 비동기 실행 규칙을 적용한다:
 - `codex-review` CLI wrapper 사용
 - 비동기 실행: `start`/`follow-up` → `status` 폴링 → 결과 수집
 - Exit code 기반 에러 처리 (review-protocol.md 참조)
-- 2분 초과 시 사용자 알림 (계속/취소/PASS)
+- 묻지 않고 계속 대기, 2분마다 진행 안내 (중단은 사용자가 직접 `/codex-core:halt`)
 
 ### 파일 네이밍 (Delegate 전용)
 

--- a/plugins/codex-core/rules/review-protocol.md
+++ b/plugins/codex-core/rules/review-protocol.md
@@ -151,7 +151,7 @@ node "{HOME_LITERAL}/.claude/bin/codex-review.mjs" status --session "cr_{SID}" -
 | Exit Code | 상태 | 처리 |
 |:---------:|------|------|
 | 0 | `completed` | **Step 3으로 진행** — 출력 파일 읽기 |
-| 7 | `running` / `initializing` / `queued` | **30초 후 재폴링** (아래 사용자 알림 임계치 참조) |
+| 7 | `running` / `initializing` / `queued` | **30초 후 재폴링** (아래 진행 안내 규칙 참조) |
 | 5 | `timeout_partial` | 부분 출력 저장됨 — Step 3으로 진행 (출력 파일 읽기) |
 | 8 | `cancelled` | 취소됨 — 부분 출력이 있으면 읽기 |
 | 6 | `crashed` / `failed` | 에러 처리 섹션 참조 |
@@ -169,29 +169,25 @@ node "{HOME_LITERAL}/.claude/bin/codex-review.mjs" status --session "cr_{SID}" -
 }
 ```
 
-**사용자 알림 임계치**: status에서 `elapsedMs`가 **120초(2분)**를 초과하고 아직 `running`이면,
-**AskUserQuestion**으로 사용자에게 상황을 보고하고 결정을 받는다:
+**진행 안내 규칙**: Codex 요청은 수 분이 걸릴 수 있으므로, **중간에 사용자에게 계속할지 묻지 않고 계속 대기**한다.
+대신 진행 상황만 주기적으로 텍스트로 안내한다.
 
-```json
-{
-  "questions": [{
-    "question": "Codex 리뷰가 {elapsed}초째 진행 중입니다 (현재 {charsReceived}자 수신). 어떻게 할까요?",
-    "header": "Review Progress",
-    "multiSelect": false,
-    "options": [
-      {"label": "계속 대기", "description": "리뷰가 완료될 때까지 기다립니다 (30초 후 다시 확인)"},
-      {"label": "취소 후 부분 결과 사용", "description": "현재까지 수신된 내용으로 진행합니다"},
-      {"label": "PASS", "description": "리뷰를 건너뛰고 다음 단계로 진행합니다"}
-    ]
-  }]
-}
-```
+| 항목 | 규칙 |
+|------|------|
+| 폴링 간격 | **30초** (변함없음 — exit 7이면 계속 재폴링) |
+| 진행 안내 주기 | **2분(120초)마다 1회**, 한 줄로 경과 시간과 수신량을 안내 |
+| 안내 형식 | `Codex 진행 중 — {elapsed}초 경과, {charsReceived}자 수신` (예: `Codex 진행 중 — 240초 경과, 5,120자 수신`) |
+| 종료 조건 | `status`가 exit 0(completed) 또는 exit 5(timeout_partial)를 반환할 때까지 폴링 지속 |
+| 하드 타임아웃 | **30분 safety net 유지** — `status`가 exit 5(`timeout_partial`)를 반환하면 부분 출력으로 Step 3 진행 |
 
-> **"계속 대기" 선택 시**: 30초 후 다시 status를 확인한다. 이후 **60초마다** 재알림한다.
-> **"취소 후 부분 결과 사용" 선택 시**: `cancel` 명령 실행 → 부분 출력 파일 읽기 → PHASE 3 진행.
-> **"PASS" 선택 시**: `cancel` 명령 실행 → 검증 스킵.
+> **⛔ AskUserQuestion 금지**: 대기 시간이 길다는 이유만으로 사용자에게 계속/취소/PASS를 묻지 않는다.
+> 사용자가 멈추고 싶으면 직접 `/codex-core:halt`(또는 `/codex-core:sessions`로 확인 후 halt)를 호출하거나 세션에 개입한다.
+> 이때 partial 출력과 thread state는 보존된다.
 
-**취소 명령**:
+> **안내 주기 운용**: 폴링은 30초마다 돌지만, 진행 안내 텍스트는 누적 경과가 **120초의 배수에 도달했을 때만** 1줄 출력한다
+> (240초, 360초, 480초 ... 30분까지). 30초 폴링마다 매번 출력하지 않는다.
+
+**취소 명령** (사용자가 직접 중단을 요청했을 때만):
 ```bash
 node "{HOME_LITERAL}/.claude/bin/codex-review.mjs" cancel --session "cr_{SID}" --review-dir "{HOME_LITERAL}/.claude/tmp"
 ```
@@ -247,8 +243,8 @@ echo "EXIT_CODE: $?"
 
 PHASE 1 Step 2와 **동일한 폴링 패턴**을 사용한다:
 - 30초 간격으로 `status` 명령 호출
-- 2분 초과 시 AskUserQuestion으로 사용자 알림
-- 완료 시 출력 파일 읽기
+- 묻지 않고 계속 대기, 2분(120초)마다 진행 상황만 1줄 안내
+- 완료(exit 0) 또는 30분 하드 타임아웃(exit 5)까지 폴링 지속 → 출력 파일 읽기
 
 #### Step 3: 결과 수집
 
@@ -541,7 +537,7 @@ After all issues, provide:
 | Exit Code | 의미 | 처리 |
 |:---------:|------|------|
 | 0 | 완료 (`completed`) | 출력 파일 읽기 → PHASE 3 진행 |
-| 7 | 실행 중 (`running` / `initializing` / `queued`) | 30초 후 재폴링 (2분 초과 시 사용자 알림) |
+| 7 | 실행 중 (`running` / `initializing` / `queued`) | 30초 후 재폴링 (묻지 않고 계속 대기, 2분마다 진행 안내) |
 | 5 | 타임아웃 (`timeout_partial`, 30분 safety net) | 부분 출력 읽기 → PHASE 3 진행 |
 | 8 | 취소됨 (`cancelled`) | 부분 출력이 있으면 읽기 |
 | 1 | codex 바이너리 없음 | 즉시 PASS |
@@ -561,7 +557,7 @@ After all issues, provide:
 codex-review start → exit 0 (워커 시작됨)
   │
   ├─ status 폴링 루프 (30초 간격)
-  │   ├─ exit 7 → 실행 중 → 계속 대기 (2분 초과 시 사용자 알림)
+  │   ├─ exit 7 → 실행 중 → 묻지 않고 계속 대기 (2분마다 진행 안내, 30분 하드 타임아웃까지)
   │   ├─ exit 0 → 완료 → 출력 파일 읽기 → PHASE 3
   │   ├─ exit 5 → 타임아웃 → 부분 출력 읽기 → PHASE 3
   │   ├─ exit 8 → 취소됨 → 부분 출력 있으면 읽기


### PR DESCRIPTION
## 배경

Codex 요청(리뷰/위임)이 실제로 수 분 걸리는 경우가 많아, 기존의 "2분 초과 시 AskUserQuestion(계속/취소/PASS)" 동작이 매번 흐름을 끊는 마찰만 유발했다. 사용자는 사실상 매번 "계속 대기"만 누르게 된다.

## 변경

폴링 대기 중 **질문을 제거**하고, 대신 **2분마다 진행 상황을 1줄로 안내**하도록 규칙을 변경했다.

| 항목 | 변경 전 | 변경 후 |
|------|---------|---------|
| 2분 초과 시 | AskUserQuestion (계속/취소/PASS) | 질문 없이 계속 대기 |
| 진행 안내 | 질문할 때만 | 2분(120초)마다 1줄 (`Codex 진행 중 — {elapsed}초 경과, {chars}자 수신`) |
| 폴링 간격 | 30초 | 30초 (유지) |
| 30분 하드 타임아웃 | 유지 | 유지 (exit 5 → 부분 출력으로 진행) |
| 중단 수단 | 질문 선택지 | 사용자가 직접 `/codex-core:halt` (partial·thread state 보존) |

## 수정 파일 (4개, 문서만)

- `plugins/codex-core/rules/review-protocol.md` — canonical 정의. "사용자 알림 임계치" 블록을 "진행 안내 규칙" 표로 교체 + AskUserQuestion 금지 명시. 폴링 흐름도/Exit code 표 정정.
- `plugins/codex-core/rules/codex-delegate.md` — 폴링 참조 2곳
- `plugins/codex-code-review/rules/codex-code-review.md` — 폴링 참조 2곳 (+ 잘못된 `Step 3` 참조를 `Step 2`로 정정)
- `plugins/codex-code-review/rules/codex-red-review.md` — 폴링 참조 1곳

## 영향 없는 부분 (의도적 유지)

- HIGH 이슈 결정, 빈 diff 종료 확인, delegate Turn≥10/막힘 개입, 복수 세션 중단 대상 선택 등 **진짜 의사결정용 AskUserQuestion**은 그대로 유지
- CLI(`codex-review.mjs`)는 폴링 인프라만 제공 → 코드 변경 없음 (규칙 레이어에서만 처리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)