### PR TITLE
feat(codex-core): codex CLI 미설치 시 설치된 Codex 앱 바이너리 자동 탐색 + symlink

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "sanghyun-io's Claude Code plugins",
-    "version": "2.2.2"
+    "version": "2.3.0"
   },
   "plugins": [
     {
       "name": "codex-core",
       "source": "./plugins/codex-core",
       "description": "Codex integration for Claude Code — natural language router, A+ delegation, session ops, and the codex-review CLI runtime",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "author": { "name": "sanghyun-io" },
       "homepage": "https://github.com/sanghyun-io/codex-app-server-plugin",
       "license": "MIT",

--- a/plugins/codex-core/.claude-plugin/plugin.json
+++ b/plugins/codex-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-core",
   "description": "Codex integration for Claude Code — natural language router, A+ delegation, session ops, and the codex-review CLI runtime",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "author": {
     "name": "sanghyun-io",
     "email": "ppkimsanh@gmail.com"

--- a/plugins/codex-core/bin/broker.mjs
+++ b/plugins/codex-core/bin/broker.mjs
@@ -82,6 +82,45 @@ function isTurnScopedMethod(method) {
 }
 
 // ---------------------------------------------------------------------------
+// Codex binary resolution (mirrors codex-review.mjs resolveCodexLauncher)
+// ---------------------------------------------------------------------------
+
+/**
+ * Decide how to launch the codex app-server.
+ *   1. CODEX_BINARY env — run via `node <bin>` (test fakes / explicit override)
+ *   2. ~/.claude/bin/codex — symlink installed by /codex-core:setup
+ *   3. PATH `codex` (Windows via `cmd /c codex`)
+ */
+function resolveCodexLauncher() {
+  const customBin = process.env.CODEX_BINARY;
+  if (customBin) {
+    // Preserve original test-fake invocation: `node <bin>` with no "app-server" arg.
+    return { command: process.execPath, prependArgs: [customBin], passAppServerArg: false };
+  }
+
+  if (HOME) {
+    const isWin = process.platform === "win32";
+    const candidates = isWin
+      ? ["codex.cmd", "codex.exe", "codex.ps1", "codex"]
+      : ["codex"];
+    for (const name of candidates) {
+      const p = resolve(HOME, ".claude", "bin", name);
+      if (existsSync(p)) {
+        if (p.endsWith(".ps1")) {
+          return { command: "powershell", prependArgs: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", p], passAppServerArg: true };
+        }
+        return { command: p, prependArgs: [], passAppServerArg: true };
+      }
+    }
+  }
+
+  if (process.platform === "win32") {
+    return { command: "cmd", prependArgs: ["/c", "codex"], passAppServerArg: true };
+  }
+  return { command: "codex", prependArgs: [], passAppServerArg: true };
+}
+
+// ---------------------------------------------------------------------------
 // Logging
 // ---------------------------------------------------------------------------
 
@@ -113,23 +152,12 @@ class AppServerConnection {
 
   async start() {
     return new Promise((resolveP, rejectP) => {
-      const customBin = process.env.CODEX_BINARY;
-      if (customBin) {
-        this.proc = spawn(process.execPath, [customBin], {
-          stdio: ["pipe", "pipe", "pipe"],
-          windowsHide: true,
-        });
-      } else {
-        const isWin = process.platform === "win32";
-        this.proc = isWin
-          ? spawn("cmd", ["/c", "codex", "app-server"], {
-              stdio: ["pipe", "pipe", "pipe"],
-              windowsHide: true,
-            })
-          : spawn("codex", ["app-server"], {
-              stdio: ["pipe", "pipe", "pipe"],
-            });
-      }
+      const { command, prependArgs, passAppServerArg } = resolveCodexLauncher();
+      const spawnArgs = passAppServerArg ? [...prependArgs, "app-server"] : [...prependArgs];
+      this.proc = spawn(command, spawnArgs, {
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+      });
 
       this.proc.on("error", (err) => {
         if (err.code === "ENOENT") {

--- a/plugins/codex-core/bin/codex-review.mjs
+++ b/plugins/codex-core/bin/codex-review.mjs
@@ -52,6 +52,60 @@ const CANCEL_CHECK_MS = 500;               // 500ms cancel signal polling
 const SELF = fileURLToPath(import.meta.url);
 
 // ---------------------------------------------------------------------------
+// Codex binary resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Decide how to launch the codex app-server.
+ *
+ * Resolution order:
+ *   1. CODEX_BINARY env — run via `node <bin>` (test fakes / explicit override)
+ *   2. ~/.claude/bin/codex — symlink installed by /codex-core:setup when the
+ *      codex CLI isn't on PATH but a desktop-app binary was found. Using the
+ *      absolute path means it works even if ~/.claude/bin is not on PATH.
+ *   3. PATH `codex` — the normal case (npm -g / standalone installer / brew).
+ *      On Windows we go through `cmd /c codex` so the .ps1/.cmd shim resolves.
+ *
+ * Returns { command, prependArgs, passAppServerArg }:
+ *   - command + prependArgs: how to invoke the process
+ *   - passAppServerArg: whether to append the "app-server" arg. For the
+ *     CODEX_BINARY test fake this is false (it preserves the original
+ *     `node <bin>` invocation, which did NOT pass "app-server"); every real
+ *     codex launch sets it true.
+ */
+function resolveCodexLauncher() {
+  const customBin = process.env.CODEX_BINARY;
+  if (customBin) {
+    return { command: process.execPath, prependArgs: [customBin], passAppServerArg: false };
+  }
+
+  const home = process.env.HOME || process.env.USERPROFILE || "";
+  if (home) {
+    const isWin = process.platform === "win32";
+    // setup symlinks/copies to ~/.claude/bin/codex (or codex.cmd/.exe on Windows)
+    const candidates = isWin
+      ? ["codex.cmd", "codex.exe", "codex.ps1", "codex"]
+      : ["codex"];
+    for (const name of candidates) {
+      const p = resolve(home, ".claude", "bin", name);
+      if (existsSync(p)) {
+        // .ps1 must be run through PowerShell; everything else runs directly.
+        if (p.endsWith(".ps1")) {
+          return { command: "powershell", prependArgs: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", p], passAppServerArg: true };
+        }
+        return { command: p, prependArgs: [], passAppServerArg: true };
+      }
+    }
+  }
+
+  // Fall back to PATH lookup.
+  if (process.platform === "win32") {
+    return { command: "cmd", prependArgs: ["/c", "codex"], passAppServerArg: true };
+  }
+  return { command: "codex", prependArgs: [], passAppServerArg: true };
+}
+
+// ---------------------------------------------------------------------------
 // CodexError
 // ---------------------------------------------------------------------------
 
@@ -81,28 +135,16 @@ class AppServerClient {
 
   async spawn() {
     return new Promise((resolveP, rejectP) => {
-      const customBin = process.env.CODEX_BINARY;
-      if (customBin) {
-        // Custom binary (e.g. fake-codex.mjs for testing)
-        this.proc = spawn(process.execPath, [customBin], {
-          stdio: ["pipe", "pipe", "pipe"],
-          windowsHide: true,
-        });
-      } else {
-        const isWin = process.platform === "win32";
-        this.proc = isWin
-          ? spawn("cmd", ["/c", "codex", "app-server"], {
-              stdio: ["pipe", "pipe", "pipe"],
-              windowsHide: true,
-            })
-          : spawn("codex", ["app-server"], {
-              stdio: ["pipe", "pipe", "pipe"],
-            });
-      }
+      const { command, prependArgs, passAppServerArg } = resolveCodexLauncher();
+      const spawnArgs = passAppServerArg ? [...prependArgs, "app-server"] : [...prependArgs];
+      this.proc = spawn(command, spawnArgs, {
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+      });
 
       this.proc.on("error", (err) => {
         if (err.code === "ENOENT") {
-          rejectP(new CodexError(1, "codex binary not found. Install with: npm i -g @anthropic-ai/codex"));
+          rejectP(new CodexError(1, "codex binary not found. Install the codex CLI (npm i -g @openai/codex) or run /codex-core:setup to link an installed Codex app."));
         } else {
           rejectP(new CodexError(6, `Process spawn error: ${err.message}`));
         }

--- a/plugins/codex-core/skills/setup/SKILL.md
+++ b/plugins/codex-core/skills/setup/SKILL.md
@@ -237,12 +237,73 @@ echo "PATH=$CODEX_PATH VER=$CODEX_VER"
 - Stop and wait for user to reinstall, then re-run setup.
 
 **If NOT_FOUND**:
-Ask the user using AskUserQuestion:
+The codex CLI isn't on PATH. Before asking the user to install it, **try to auto-discover an existing Codex binary** (e.g. installed by the Codex desktop app, Homebrew cask, or the standalone installer) and symlink it into `~/.claude/bin/codex` — the plugin runtime checks that path directly, so no PATH change is needed.
+
+> **⛔ 경로 추측 금지**: OpenAI 공식 문서는 OS별 Codex 앱 바이너리 경로를 명시하지 않는다.
+> 아래는 표준 설치구(standalone installer / Homebrew cask / GitHub release)가 흔히 쓰는 **후보 경로 + 동적 탐색**이다.
+> **존재하고 실행 가능한 것만** symlink한다. 하나도 못 찾으면 추측해서 만들지 말고 npm 설치 안내로 넘어간다.
+
+Run the auto-discovery with Bash:
+
+```bash
+FOUND=""
+
+# 1) macOS: Spotlight로 Codex.app 동적 탐색 후, 번들 내부 codex 바이너리 추적
+if [ "$(uname)" = "Darwin" ]; then
+  APP=$(mdfind "kMDItemCFBundleIdentifier == 'com.openai.codex'" 2>/dev/null | head -1)
+  [ -z "$APP" ] && APP=$(mdfind -name "Codex.app" 2>/dev/null | grep -i '/Codex.app$' | head -1)
+  if [ -n "$APP" ]; then
+    # 번들 안에서 실행 가능한 codex 바이너리 탐색 (Resources/MacOS 등 위치 변동 대비)
+    FOUND=$(find "$APP" -type f \( -name "codex" -o -name "codex-*-apple-darwin" \) -perm -u+x 2>/dev/null | head -1)
+  fi
+fi
+
+# 2) 후보 경로 목록 (mac/linux 공통 — standalone installer / homebrew cask / 수동 설치)
+if [ -z "$FOUND" ]; then
+  for cand in \
+    "$HOME/.codex/bin/codex" \
+    "$HOME/.local/bin/codex" \
+    "/opt/homebrew/bin/codex" \
+    "/usr/local/bin/codex" \
+    "/opt/codex/bin/codex" \
+    "/opt/codex/codex" ; do
+    if [ -x "$cand" ]; then FOUND="$cand"; break; fi
+  done
+fi
+
+# 3) Windows: where.exe + 흔한 설치 경로 (Git Bash/WSL 가정). MS Store 격리본은 symlink 부적합 → 발견 못하면 npm 안내로.
+if [ -z "$FOUND" ] && command -v where.exe >/dev/null 2>&1; then
+  W=$(where.exe codex.exe 2>/dev/null | head -1 | tr -d '\r')
+  [ -n "$W" ] && [ -f "$W" ] && FOUND="$W"
+fi
+
+if [ -n "$FOUND" ]; then
+  echo "DISCOVERED: $FOUND"
+  # 실행 검증 — 진짜 codex인지 --version으로 확인
+  "$FOUND" --version >/dev/null 2>&1 && echo "RUNNABLE: yes" || echo "RUNNABLE: no"
+else
+  echo "DISCOVERED: none"
+fi
+```
+
+**If `DISCOVERED` is a path and `RUNNABLE: yes`** — symlink it and confirm:
+
+```bash
+mkdir -p ~/.claude/bin
+ln -sf "$FOUND" ~/.claude/bin/codex 2>/dev/null \
+  || cp "$FOUND" ~/.claude/bin/codex   # symlink 불가 환경(일부 Windows)에서는 복사로 대체
+chmod +x ~/.claude/bin/codex 2>/dev/null
+~/.claude/bin/codex --version && echo "✓ Linked existing Codex binary → ~/.claude/bin/codex"
+```
+
+Then show "✓ codex 바이너리를 찾아 연결했습니다 (`{FOUND}` → ~/.claude/bin/codex)" and proceed to Step 4. **Do not ask about npm install** — codex is now resolvable.
+
+**If `DISCOVERED: none` (or `RUNNABLE: no`)** — fall back to asking the user:
 
 ```json
 {
   "questions": [{
-    "question": "codex CLI가 설치되어 있지 않습니다. 어떻게 하시겠어요?",
+    "question": "codex CLI가 설치되어 있지 않고, 설치된 Codex 앱 바이너리도 찾지 못했습니다. 어떻게 하시겠어요?",
     "header": "codex CLI",
     "multiSelect": false,
     "options": [
@@ -368,6 +429,7 @@ Show the final summary:
   ✓ ~/.claude/rules/*.md
     (codex-core: review-protocol, codex-delegation, codex-delegate, codex-session-ops)
     (codex-code-review (선택): codex-code-review, codex-red-review)
+  ✓ ~/.claude/bin/codex   ← (Step 3에서 기존 Codex 앱/바이너리를 찾아 연결한 경우에만 표시)
 
 기본 사용 (codex-core):
   • 작업 위임:      /codex-core:delegate <task>


### PR DESCRIPTION
## 배경

codex CLI를 `npm i -g @openai/codex`로 설치하지 않았더라도, OS에 **Codex 데스크톱 앱**(또는 standalone installer / Homebrew cask)이 이미 설치돼 있는 경우가 있다. 이때 그 바이너리를 찾아 `~/.claude/bin/codex`로 symlink하여 별도 CLI 설치 없이 플러그인이 동작하도록 개선한다.

## 변경

### 런타임 (`codex-review.mjs`, `broker.mjs`)

`resolveCodexLauncher()` 헬퍼를 추가하여 codex 실행 경로를 결정한다:

1. `CODEX_BINARY` env (테스트 fake / 명시적 오버라이드)
2. **`~/.claude/bin/codex`** — setup이 만든 symlink. **절대경로로 직접 실행**하므로 `~/.claude/bin`이 PATH에 없어도 동작
3. PATH의 `codex` (Windows는 `cmd /c codex`) — 기존 동작

> `CODEX_BINARY` 경로는 원본과 동일하게 `app-server` 인자를 넘기지 않도록 `passAppServerArg`로 분기 — 기존 테스트 동작을 바이트 단위로 보존.

### setup (`skills/setup/SKILL.md`)

Step 3에서 codex 미발견 시, npm 설치를 묻기 **전에** OS별 바이너리를 동적 탐색:

- **macOS**: `mdfind`/Spotlight로 `Codex.app` 탐색 → 번들 내부 codex 바이너리 추적
- **mac/Linux 공통**: `~/.codex/bin`, `~/.local/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, `/opt/codex` 후보 경로
- **Windows**: `where.exe codex.exe` (MS Store 격리본은 symlink 부적합 → 미발견 시 기존 npm 안내)

발견 + `--version` 동작 확인된 것만 `~/.claude/bin/codex`로 symlink(불가 시 copy).

> **경로 추측 금지**: OpenAI 공식 문서가 OS별 앱 바이너리 경로를 명시하지 않으므로(조사 확인), 단일 경로 하드코딩 대신 **동적 탐색 + 검증된 후보 목록**으로 구현. 존재·실행 가능한 것만 연결.

## 버전

- codex-core: 2.2.2 → **2.3.0** (기능 추가)
- marketplace.json: metadata + codex-core 엔트리 동기화
- codex-code-review: 2.2.2 유지 (변경 없음)

## 테스트

- 의미 있는 테스트(model reuse, auth, foreground, broker delta 분리 등) 전부 통과
- `broker turn serialization` 테스트는 **main에서도 6회 중 2회 실패**하는 기존 flaky(소켓 타이밍 민감) 테스트로, 본 변경과 무관함을 교차 검증함 (이번 PR 범위 밖)

🤖 Generated with [Claude Code](https://claude.com/claude-code)